### PR TITLE
fix: Convert Contribute Code button to link opening GitHub repo

### DIFF
--- a/frontend/src/components/explore/OpenSourceVision.jsx
+++ b/frontend/src/components/explore/OpenSourceVision.jsx
@@ -15,9 +15,14 @@ export default function OpenSourceVision() {
             </p>
           </div>
           <div className="w-full flex justify-center lg:justify-end">
-            <button className="mt-10 w-full sm:w-auto px-8 sm:px-10 py-4 sm:py-5 bg-white text-black text-base sm:text-lg font-black uppercase tracking-widest hover:bg-gray-100 transition-colors border-[4px] border-black rounded-none shadow-[8px_8px_0_0_rgba(0,0,0,1)] md:hover:-translate-y-1">
+            <a
+              href="https://github.com/kunalverma2512/CodeLens"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-10 w-full sm:w-auto px-8 sm:px-10 py-4 sm:py-5 bg-white text-black text-base sm:text-lg font-black uppercase tracking-widest hover:bg-gray-100 transition-colors border-[4px] border-black rounded-none shadow-[8px_8px_0_0_rgba(0,0,0,1)] md:hover:-translate-y-1 inline-block text-center"
+            >
               Contribute Code
-            </button>
+            </a>
           </div>
         </div>
         <div className="flex-1 w-full grid grid-cols-2 gap-4 sm:gap-6">


### PR DESCRIPTION
## Summary

This PR converts the 'Contribute Code' button from a non-functional button element to a functional link that opens the GitHub repository.

## Changes

- Replaced \<button>\ with \<a>\ tag
- Added \href\ pointing to the GitHub repository
- Added \	arget='_blank'\ to open in new tab
- Added \el='noopener noreferrer'\ for security
- Preserved all existing styling and hover effects
- Added \inline-block\ and \	ext-center\ for proper link styling

## Testing

- Clicking the button now opens the GitHub repository in a new tab
- All visual styling preserved (shadows, borders, hover effects)
- Responsive behavior maintained

Fixes: #13