### PR TITLE
feat: add toggle password visibility with eye icon in signin and signup pages

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,6 +1,9 @@
 import { Link } from 'react-router-dom';
+import { useState } from 'react';
 
 export default function LoginPage() {
+  const [showPassword, setShowPassword] = useState(false);
+
   return (
     <div className="w-full flex-1 flex flex-col items-center justify-center px-8 py-20 bg-white">
       <div className="w-full max-w-md border-[4px] border-black p-12 bg-white shadow-[16px_16px_0_0_rgba(0,0,0,1)]">
@@ -22,11 +25,32 @@ export default function LoginPage() {
             <label className="text-sm font-black uppercase tracking-widest text-black">
               Password
             </label>
-            <input 
-              type="password" 
-              className="w-full p-5 border-[4px] border-black rounded-none text-black font-bold focus:outline-none focus:ring-0 focus:border-gray-500"
-              placeholder="••••••••"
-            />
+            <div className="relative">
+              <input 
+                type={ showPassword ? "text" : "password" }
+                className="w-full p-5 border-[4px] border-black rounded-none text-black font-bold focus:outline-none focus:ring-0 focus:border-gray-500"
+                placeholder="••••••••"
+              />
+
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-4 top-1/2 -translate-y-1/2 text-black"
+              >
+                {showPassword ? (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+                    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+                    <line x1="1" y1="1" x2="23" y2="23" />
+                  </svg>
+                  ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                    <circle cx="12" cy="12" r="3" />
+                  </svg>
+                )}
+              </button>
+            </div>
           </div>
           <button 
             type="submit" 

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router-dom';
+import { useState } from 'react';
 
 export default function SignupPage() {
+  const [showPassword, setShowPassword] = useState(false);
   return (
     <div className="w-full flex-1 flex flex-col items-center justify-center px-8 py-20 bg-white">
       <div className="w-full max-w-md border-[4px] border-black p-12 bg-white shadow-[16px_16px_0_0_rgba(0,0,0,1)]">
@@ -32,11 +34,32 @@ export default function SignupPage() {
             <label className="text-sm font-black uppercase tracking-widest text-black">
               Password
             </label>
-            <input 
-              type="password" 
-              className="w-full p-5 border-[4px] border-black rounded-none text-black font-bold focus:outline-none focus:ring-0 focus:border-gray-500"
-              placeholder="••••••••"
-            />
+            <div className="relative">
+              <input 
+                type={showPassword ? "text" : "password"} 
+                className="w-full p-5 border-[4px] border-black rounded-none text-black font-bold focus:outline-none focus:ring-0 focus:border-gray-500"
+                placeholder="••••••••"
+              />
+
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-4 top-1/2 -translate-y-1/2 text-black"
+              >
+                {showPassword ? (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+                    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+                    <line x1="1" y1="1" x2="23" y2="23" />
+                  </svg>
+                  ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                    <circle cx="12" cy="12" r="3" />
+                  </svg>
+                )}
+              </button>
+            </div>
           </div>
           <button 
             type="submit" 


### PR DESCRIPTION
## Feature: Toggle Password Visibility
### Fixed Issue: #4 

- Added eye icon inside password input fields
- Users can toggle between hidden and visible password
- Applied changes to LoginPage.jsx and SignupPage.jsx

## Screenshots

### Signup (Before)
<img width="939" height="408" alt="{B9FCE7CB-ED5A-4D16-95D2-88F2A522EF64}" src="https://github.com/user-attachments/assets/99adce1a-cc87-48eb-b496-9f69eca48caa" />

### Signup (After)
<img width="944" height="415" alt="{E8F6034C-D4D3-43A2-B433-CA5CDA2B7E5A}" src="https://github.com/user-attachments/assets/eaf6d312-6dca-420b-b49b-23c132683914" />


### Signin (Before)
<img width="944" height="415" alt="{5C260B71-2C6D-43C9-9D3F-FB15CF270E36}" src="https://github.com/user-attachments/assets/753aa1c0-431f-4d27-baba-43d07fffdfa6" />

### Signin (After)
<img width="947" height="414" alt="{6723440B-52F6-4273-8380-79E051D5FF73}" src="https://github.com/user-attachments/assets/51d3cee5-3edb-47d4-ad5b-a5ed80651656" />


## Why
Improves user experience by allowing users to verify their password input.

## Changes
- Added useState for visibility toggle
- Updated input type dynamically
- Added clickable icon