### PR TITLE
chore: setup stale bot workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,35 @@
+name: Close stale issues and PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Mark stale issues and PRs
+        uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been marked as stale due to inactivity.
+            Please add updates or comments to keep it active.
+
+          stale-pr-message: >
+            This pull request has been marked as stale due to inactivity.
+            Please add updates or commits to keep it active.
+
+          close-issue-message: >
+            Closing this issue due to prolonged inactivity.
+
+          close-pr-message: >
+            Closing this pull request due to prolonged inactivity.
+
+          days-before-stale: 14
+          days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Mark stale issues and PRs
-        uses: actions/stale@v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
         with:
           stale-issue-message: >
             This issue has been marked as stale due to inactivity.


### PR DESCRIPTION
#63 

## Summary
Added a stale bot workflow using `actions/stale@v9` to manage inactive issues and pull requests automatically.

## Changes Made
* Added `.github/workflows/stale.yml`
* Configured stale checks with GitHub Actions
* Added stale and close reminder messages
* Validated the YAML configuration before submission
* Set:
  * `days-before-stale: 14`
  * `days-before-close: 7`


## Result
This helps keep the repository cleaner by automatically marking and closing inactive issues and PRs after a period of inactivity.

## Notes for Reviewer/Moderator
Please add `gssoc:approved` label so that it gets counted for GSSoC'26

## Edits Made
Updated `actions/stale` with a full commit SHA instead of using `@v9`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Added automated repository maintenance to detect and manage inactive issues and pull requests.
  * Inactive items are marked as stale after 14 days with a reminder; items are closed after an additional 7 days if no activity.
  * Maintenance runs daily and can also be triggered manually.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kunalverma2512/CodeLens/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->