### PR TITLE
feat: redesign NotFoundPage with modern brutalist responsive layout

### DIFF
--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -2,205 +2,93 @@ import { Link } from "react-router-dom";
 
 export default function NotFoundPage() {
   return (
-    <section className="relative min-h-screen w-full overflow-hidden bg-white border-t-4 border-black">
-      
+    <main
+      className="relative min-h-screen overflow-hidden border-t-4 border-black bg-white"
+      aria-label="404 Not Found Page"
+    >
       {/* Background Grid */}
-      <div className="absolute inset-0 grid grid-cols-6 lg:grid-cols-12 pointer-events-none">
-        {Array.from({ length: 12 }).map((_, i) => (
-          <div
-            key={i}
-            className="border-r border-black/10 h-full"
-          />
-        ))}
-      </div>
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          backgroundImage:
+            "repeating-linear-gradient(90deg, rgba(0,0,0,0.04) 0px, rgba(0,0,0,0.04) 1px, transparent 1px, transparent calc(100% / 12))",
+        }}
+      />
 
-      {/* Main Layout */}
-      <div className="relative z-10 min-h-screen flex flex-col lg:flex-row">
-        
+      <div className="relative z-10 mx-auto flex flex-1 max-w-screen-2xl flex-col lg:flex-row">
         {/* LEFT PANEL */}
-        <div className="relative flex-[1.1] border-b-4 lg:border-b-0 lg:border-r-4 border-black overflow-hidden flex flex-col justify-between px-6 sm:px-10 py-16 lg:py-20">
-          
-          {/* Background 404 */}
-          <p className="absolute inset-0 flex items-center justify-center text-[55vw] lg:text-[30vw] font-black tracking-tighter leading-none text-black opacity-[0.04] pointer-events-none select-none">
+        <div className="relative flex-1 overflow-hidden border-b-4 border-black px-6 py-16 sm:px-10 lg:border-r-4 lg:border-b-0 lg:py-20">
+          {/* Ghost 404 */}
+          <p
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 flex select-none items-center justify-center text-[clamp(10rem,35vw,30rem)] font-black tracking-tighter text-black opacity-[0.06]"
+          >
             404
           </p>
 
-          {/* Foreground Content */}
-          <div className="relative z-10 flex flex-col justify-between h-full w-full">
-            
-            {/* Top Label */}
+          <div className="relative z-10 flex h-full flex-col justify-between">
+            {/* Label */}
             <div>
-              <p className="text-xs sm:text-sm font-black uppercase tracking-[0.35em] text-black">
+              <p className="text-xs font-black uppercase tracking-[0.35em] text-black sm:text-sm">
                 Error / Route Unavailable
               </p>
             </div>
 
-            {/* Main 404 Content */}
-            <div className="flex flex-col items-start py-12 lg:py-0">
-              
-              <h1 className="text-[5rem] sm:text-[7rem] md:text-[9rem] xl:text-[12rem] font-black uppercase tracking-tighter leading-[0.85] text-black">
+            {/* Main Content */}
+            <div className="py-12 lg:py-0">
+              <h1 className="text-[clamp(5rem,12vw,12rem)] font-black uppercase leading-[0.85] tracking-tighter text-black">
                 404
               </h1>
 
-              <div className="mt-8 w-32 h-[6px] bg-black" />
+              <div className="mt-8 h-[6px] w-32 bg-black" />
 
-              <h2 className="mt-10 text-4xl sm:text-5xl md:text-6xl xl:text-[6rem] font-black uppercase tracking-tighter leading-[0.9] text-black">
+              <h2 className="mt-10 text-[clamp(3rem,7vw,6rem)] font-black uppercase leading-[0.9] tracking-tighter text-black">
                 Page
                 <br />
                 Not Found.
               </h2>
             </div>
 
-            {/* Bottom Description */}
-            <div className="max-w-xl pt-10">
-              <p className="text-lg md:text-xl xl:text-2xl font-bold leading-relaxed text-black">
-                The requested route does not exist,
-                may have been moved, or is currently unavailable.
+            {/* Description */}
+            <div className="max-w-xl">
+              <p className="text-lg font-medium leading-relaxed text-black md:text-xl">
+                The page you're looking for doesn't exist, may have been moved,
+                or is temporarily unavailable.
               </p>
             </div>
           </div>
         </div>
 
         {/* RIGHT PANEL */}
-        <div className="flex-1 flex flex-col justify-between px-6 sm:px-10 md:px-16 lg:px-20 xl:px-24 py-16 lg:py-20">
-          
-          {/* TOP CONTENT */}
-          <div>
-            
-            <p className="max-w-3xl text-lg md:text-xl xl:text-2xl font-bold leading-relaxed text-black">
-              Double-check the URL or continue navigating
-              through the platform using the available
-              navigation options below.
+        <div className="flex flex-1 items-center px-6 py-16 sm:px-10 md:px-16 lg:px-20 lg:py-20">
+          <div className="max-w-xl">
+            <p className="text-2xl font-medium leading-relaxed text-black md:text-3xl">
+              Double-check the URL or continue exploring the platform using one
+              of the options below.
             </p>
 
-            {/* CTA BUTTONS */}
-            <div className="mt-16 flex flex-col sm:flex-row flex-wrap gap-5">
-              
+            {/* Actions */}
+            <nav
+              aria-label="404 page actions"
+              className="mt-12 flex flex-wrap gap-5"
+            >
               <Link
                 to="/"
-                className="inline-flex items-center justify-center border-4 border-black bg-black px-10 py-5 text-sm sm:text-base font-black uppercase tracking-widest text-white transition-all duration-200 hover:bg-white hover:text-black hover:-translate-y-1"
+                className="inline-flex transform-gpu items-center justify-center border-4 border-black bg-black px-10 py-5 text-sm font-black uppercase tracking-[0.2em] text-white transition-all duration-200 hover:-translate-y-1 hover:bg-white hover:text-black focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
               >
                 Go Home
               </Link>
 
               <Link
                 to="/explore"
-                className="inline-flex items-center justify-center border-4 border-black bg-white px-10 py-5 text-sm sm:text-base font-black uppercase tracking-widest text-black transition-all duration-200 hover:bg-black hover:text-white hover:-translate-y-1"
+                className="inline-flex transform-gpu items-center justify-center border-4 border-black bg-white px-10 py-5 text-sm font-black uppercase tracking-[0.2em] text-black transition-all duration-200 hover:-translate-y-1 hover:bg-black hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
               >
                 Explore
               </Link>
-
-              <Link
-                to="/dashboard"
-                className="inline-flex items-center justify-center border-4 border-black bg-white px-10 py-5 text-sm sm:text-base font-black uppercase tracking-widest text-black transition-all duration-200 hover:bg-black hover:text-white hover:-translate-y-1"
-              >
-                Dashboard
-              </Link>
-            </div>
-          </div>
-
-          {/* BOTTOM SECTION */}
-          <div className="mt-28 border-t-4 border-black pt-12 grid grid-cols-1 xl:grid-cols-2 gap-12">
-            
-            {/* STATUS PANEL */}
-            <div className="border-4 border-black bg-white max-w-xl">
-              
-              <div className="border-b-4 border-black px-6 py-5">
-                <p className="text-xs font-black uppercase tracking-[0.3em] text-black">
-                  System Status
-                </p>
-              </div>
-
-              <div className="flex flex-col divide-y-4 divide-black">
-                
-                <div className="px-6 py-6">
-                  <p className="text-xs uppercase tracking-widest font-black text-black mb-3">
-                    Error Code
-                  </p>
-
-                  <p className="text-5xl font-black text-black">
-                    404
-                  </p>
-                </div>
-
-                <div className="px-6 py-6">
-                  <p className="text-xs uppercase tracking-widest font-black text-black mb-3">
-                    Requested Status
-                  </p>
-
-                  <p className="text-xl font-black uppercase text-black leading-tight">
-                    Route Not Found
-                  </p>
-                </div>
-
-                <div className="px-6 py-6">
-                  <p className="text-xs uppercase tracking-widest font-black text-black mb-3">
-                    Suggested Action
-                  </p>
-
-                  <p className="text-base md:text-lg font-bold leading-relaxed text-black">
-                    Return to the homepage or continue exploring
-                    the platform through the navigation system.
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            {/* PLATFORM ACCESS PANEL */}
-            <div className="border-4 border-black bg-white flex flex-col">
-              
-              {/* Header */}
-              <div className="border-b-4 border-black px-6 py-5">
-                <p className="text-xs font-black uppercase tracking-[0.3em] text-black">
-                  Platform Access
-                </p>
-              </div>
-
-              {/* Content */}
-              <div className="flex flex-col justify-between h-full px-6 py-8">
-                
-                {/* Branding */}
-                <div>
-                  <p className="text-lg sm:text-xl font-black uppercase tracking-[0.28em] leading-relaxed text-black">
-                    CodeLens / Developer Intelligence Platform
-                  </p>
-
-                  <p className="mt-6 text-sm md:text-base font-bold leading-relaxed text-black max-w-md">
-                    Navigate through the platform using the
-                    primary access routes below.
-                  </p>
-                </div>
-
-                {/* Navigation */}
-                <div className="mt-12 flex flex-wrap gap-6 sm:gap-10">
-                  
-                  <Link
-                    to="/"
-                    className="text-sm font-black uppercase tracking-[0.25em] text-black transition-all duration-200 hover:-translate-y-1"
-                  >
-                    Home
-                  </Link>
-
-                  <Link
-                    to="/explore"
-                    className="text-sm font-black uppercase tracking-[0.25em] text-black transition-all duration-200 hover:-translate-y-1"
-                  >
-                    Explore
-                  </Link>
-
-                  <Link
-                    to="/login"
-                    className="text-sm font-black uppercase tracking-[0.25em] text-black transition-all duration-200 hover:-translate-y-1"
-                  >
-                    Login
-                  </Link>
-                </div>
-              </div>
-            </div>
-
+            </nav>
           </div>
         </div>
       </div>
-    </section>
+    </main>
   );
 }

--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -2,46 +2,205 @@ import { Link } from "react-router-dom";
 
 export default function NotFoundPage() {
   return (
-    <div className="w-full flex-1 flex flex-col md:flex-row bg-white">
-      {/* Left panel — large 404 */}
-      <div className="flex-1 flex items-center justify-center border-b-4 md:border-b-0 md:border-r-4 border-black px-8 py-16 md:py-0">
-        <p className="text-[clamp(8rem,22vw,18rem)] font-black leading-none tracking-tighter text-black select-none">
-          404
-        </p>
+    <section className="relative min-h-screen w-full overflow-hidden bg-white border-t-4 border-black">
+      
+      {/* Background Grid */}
+      <div className="absolute inset-0 grid grid-cols-6 lg:grid-cols-12 pointer-events-none">
+        {Array.from({ length: 12 }).map((_, i) => (
+          <div
+            key={i}
+            className="border-r border-black/10 h-full"
+          />
+        ))}
       </div>
 
-      {/* Right panel — message + CTA */}
-      <div className="flex-1 flex flex-col justify-center px-10 sm:px-16 py-16 md:py-0 max-w-xl md:max-w-none">
-        <p className="text-xs font-black uppercase tracking-widest text-black mb-4">
-          Error / Not Found
-        </p>
+      {/* Main Layout */}
+      <div className="relative z-10 min-h-screen flex flex-col lg:flex-row">
+        
+        {/* LEFT PANEL */}
+        <div className="relative flex-[1.1] border-b-4 lg:border-b-0 lg:border-r-4 border-black overflow-hidden flex flex-col justify-between px-6 sm:px-10 py-16 lg:py-20">
+          
+          {/* Background 404 */}
+          <p className="absolute inset-0 flex items-center justify-center text-[55vw] lg:text-[30vw] font-black tracking-tighter leading-none text-black opacity-[0.04] pointer-events-none select-none">
+            404
+          </p>
 
-        <h1 className="text-4xl sm:text-5xl md:text-6xl font-black uppercase tracking-tighter text-black leading-tight mb-6">
-          Page not<br />found.
-        </h1>
+          {/* Foreground Content */}
+          <div className="relative z-10 flex flex-col justify-between h-full w-full">
+            
+            {/* Top Label */}
+            <div>
+              <p className="text-xs sm:text-sm font-black uppercase tracking-[0.35em] text-black">
+                Error / Route Unavailable
+              </p>
+            </div>
 
-        <div className="w-16 h-1 bg-black mb-8" />
+            {/* Main 404 Content */}
+            <div className="flex flex-col items-start py-12 lg:py-0">
+              
+              <h1 className="text-[5rem] sm:text-[7rem] md:text-[9rem] xl:text-[12rem] font-black uppercase tracking-tighter leading-[0.85] text-black">
+                404
+              </h1>
 
-        <p className="text-base sm:text-lg font-bold text-black leading-relaxed mb-12 max-w-sm">
-          The page you're looking for doesn't exist or has been moved.
-          Double-check the URL, or head back home.
-        </p>
+              <div className="mt-8 w-32 h-[6px] bg-black" />
 
-        <div className="flex flex-col sm:flex-row gap-4">
-          <Link
-            to="/"
-            className="inline-block py-5 px-10 bg-black text-white text-sm font-black uppercase tracking-widest hover:bg-white hover:text-black border-4 border-black transition-colors"
-          >
-            Go Home
-          </Link>
-          <Link
-            to="/explore"
-            className="inline-block py-5 px-10 bg-white text-black text-sm font-black uppercase tracking-widest hover:bg-black hover:text-white border-4 border-black transition-colors"
-          >
-            Explore
-          </Link>
+              <h2 className="mt-10 text-4xl sm:text-5xl md:text-6xl xl:text-[6rem] font-black uppercase tracking-tighter leading-[0.9] text-black">
+                Page
+                <br />
+                Not Found.
+              </h2>
+            </div>
+
+            {/* Bottom Description */}
+            <div className="max-w-xl pt-10">
+              <p className="text-lg md:text-xl xl:text-2xl font-bold leading-relaxed text-black">
+                The requested route does not exist,
+                may have been moved, or is currently unavailable.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* RIGHT PANEL */}
+        <div className="flex-1 flex flex-col justify-between px-6 sm:px-10 md:px-16 lg:px-20 xl:px-24 py-16 lg:py-20">
+          
+          {/* TOP CONTENT */}
+          <div>
+            
+            <p className="max-w-3xl text-lg md:text-xl xl:text-2xl font-bold leading-relaxed text-black">
+              Double-check the URL or continue navigating
+              through the platform using the available
+              navigation options below.
+            </p>
+
+            {/* CTA BUTTONS */}
+            <div className="mt-16 flex flex-col sm:flex-row flex-wrap gap-5">
+              
+              <Link
+                to="/"
+                className="inline-flex items-center justify-center border-4 border-black bg-black px-10 py-5 text-sm sm:text-base font-black uppercase tracking-widest text-white transition-all duration-200 hover:bg-white hover:text-black hover:-translate-y-1"
+              >
+                Go Home
+              </Link>
+
+              <Link
+                to="/explore"
+                className="inline-flex items-center justify-center border-4 border-black bg-white px-10 py-5 text-sm sm:text-base font-black uppercase tracking-widest text-black transition-all duration-200 hover:bg-black hover:text-white hover:-translate-y-1"
+              >
+                Explore
+              </Link>
+
+              <Link
+                to="/dashboard"
+                className="inline-flex items-center justify-center border-4 border-black bg-white px-10 py-5 text-sm sm:text-base font-black uppercase tracking-widest text-black transition-all duration-200 hover:bg-black hover:text-white hover:-translate-y-1"
+              >
+                Dashboard
+              </Link>
+            </div>
+          </div>
+
+          {/* BOTTOM SECTION */}
+          <div className="mt-28 border-t-4 border-black pt-12 grid grid-cols-1 xl:grid-cols-2 gap-12">
+            
+            {/* STATUS PANEL */}
+            <div className="border-4 border-black bg-white max-w-xl">
+              
+              <div className="border-b-4 border-black px-6 py-5">
+                <p className="text-xs font-black uppercase tracking-[0.3em] text-black">
+                  System Status
+                </p>
+              </div>
+
+              <div className="flex flex-col divide-y-4 divide-black">
+                
+                <div className="px-6 py-6">
+                  <p className="text-xs uppercase tracking-widest font-black text-black mb-3">
+                    Error Code
+                  </p>
+
+                  <p className="text-5xl font-black text-black">
+                    404
+                  </p>
+                </div>
+
+                <div className="px-6 py-6">
+                  <p className="text-xs uppercase tracking-widest font-black text-black mb-3">
+                    Requested Status
+                  </p>
+
+                  <p className="text-xl font-black uppercase text-black leading-tight">
+                    Route Not Found
+                  </p>
+                </div>
+
+                <div className="px-6 py-6">
+                  <p className="text-xs uppercase tracking-widest font-black text-black mb-3">
+                    Suggested Action
+                  </p>
+
+                  <p className="text-base md:text-lg font-bold leading-relaxed text-black">
+                    Return to the homepage or continue exploring
+                    the platform through the navigation system.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* PLATFORM ACCESS PANEL */}
+            <div className="border-4 border-black bg-white flex flex-col">
+              
+              {/* Header */}
+              <div className="border-b-4 border-black px-6 py-5">
+                <p className="text-xs font-black uppercase tracking-[0.3em] text-black">
+                  Platform Access
+                </p>
+              </div>
+
+              {/* Content */}
+              <div className="flex flex-col justify-between h-full px-6 py-8">
+                
+                {/* Branding */}
+                <div>
+                  <p className="text-lg sm:text-xl font-black uppercase tracking-[0.28em] leading-relaxed text-black">
+                    CodeLens / Developer Intelligence Platform
+                  </p>
+
+                  <p className="mt-6 text-sm md:text-base font-bold leading-relaxed text-black max-w-md">
+                    Navigate through the platform using the
+                    primary access routes below.
+                  </p>
+                </div>
+
+                {/* Navigation */}
+                <div className="mt-12 flex flex-wrap gap-6 sm:gap-10">
+                  
+                  <Link
+                    to="/"
+                    className="text-sm font-black uppercase tracking-[0.25em] text-black transition-all duration-200 hover:-translate-y-1"
+                  >
+                    Home
+                  </Link>
+
+                  <Link
+                    to="/explore"
+                    className="text-sm font-black uppercase tracking-[0.25em] text-black transition-all duration-200 hover:-translate-y-1"
+                  >
+                    Explore
+                  </Link>
+
+                  <Link
+                    to="/login"
+                    className="text-sm font-black uppercase tracking-[0.25em] text-black transition-all duration-200 hover:-translate-y-1"
+                  >
+                    Login
+                  </Link>
+                </div>
+              </div>
+            </div>
+
+          </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Related Issue

closes: #30 

## Overview

Redesigned the `NotFoundPage.jsx` with a modern full-screen brutalist-inspired responsive layout while maintaining consistency with the existing CodeLens visual system.

## Changes Made

* Reworked the entire 404 page structure into a modern split-screen layout
* Improved typography hierarchy with large-scale brutalist headings
* Added responsive full-viewport layout handling
* Added subtle background grid system for better visual depth
* Improved spacing, section balancing, and layout rhythm
* Redesigned CTA section with cleaner interactions and transitions
* Added structured system status panel
* Added platform access/navigation panel
* Improved responsiveness across desktop, tablet, and mobile layouts
* Enhanced overall visual consistency with the platform’s black-and-white brutalist aesthetic

## UI Improvements

* Better viewport utilization
* Stronger visual hierarchy
* More immersive and intentional 404 experience
* Cleaner navigation flow
* Improved component balance and readability

## Testing

* Tested on desktop viewport
* Tested responsiveness on smaller screen sizes
* Verified navigation links and layout rendering

## Screenshots

<img width="1898" height="922" alt="redsigned404page" src="https://github.com/user-attachments/assets/c41822a6-4758-4ab0-9adf-cec683ae1ba4" />
<img width="1883" height="912" alt="image" src="https://github.com/user-attachments/assets/8fe42636-e33d-4ac3-9d27-67e75a1e6fcf" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completely redesigned 404 page with a centered, bordered layout, distinct left/right panels, updated heading and copy, and two clear CTAs ("Go Home" and "Explore").

* **Styling**
  * Added a background grid layer, top-accent styling, and refined layout for improved visual hierarchy and navigation clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kunalverma2512/CodeLens/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->