### PR TITLE
cleanup: removed the Atcoder link from the footer

### DIFF
--- a/frontend/src/components/shared/Footer.jsx
+++ b/frontend/src/components/shared/Footer.jsx
@@ -81,7 +81,6 @@ export default function Footer() {
                 { label: "Codeforces API", status: "LIVE" },
                 { label: "GitHub Sync", status: "BETA" },
                 { label: "LeetCode Auth", status: "SOON" },
-                { label: "AtCoder", status: "SOON" },
               ].map((item) => (
                 <div key={item.label} className="flex items-center justify-between gap-4">
                   <a


### PR DESCRIPTION
# 📌 Pull Request Summary

## 🔗 Related Issue

Closes #149

---

## 📝 Description

This PR removes the Atcoder link from the footer of the website.

### Changes Made

* Removed the Atcoder link from the footer

### Motivation

The Atcoder link was non functional and does not redirect anywhere.

---

## 🚀 Type of Change

Select all that apply:

* [X] Enhancement


---

## 🧪 Testing

### Verification

* [X] Tested Locally
* [X] No Testing Required

## 📸 Screenshots / Demo (If Applicable)

<img width="1899" height="596" alt="image" src="https://github.com/user-attachments/assets/3f8f198a-54f4-4de1-8782-edde6ccec301" />
---

## ✅ Checklist

* [X] I have read and followed the contribution guidelines.
* [X] I have self-reviewed my changes.
* [X] My changes are limited to the scope of this issue.
* [X] Documentation has been updated where necessary.
* [X] No unnecessary files or unrelated changes have been included.
* [X] The related issue has been linked correctly.
* [X] All applicable testing and validation steps have been completed.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated available integrations in footer. Added Codeforces API (live), GitHub Sync (beta), and LeetCode Auth (coming soon).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->