### PR TITLE
fix: prevent Practice clear-all crash

### DIFF
--- a/frontend/src/pages/PracticePage.jsx
+++ b/frontend/src/pages/PracticePage.jsx
@@ -332,7 +332,6 @@ export default function PracticePage() {
 
   const clearAll = () => {
     setSearchQuery("");
-    setDebouncedSearch("");
     setSelectedTags([]);
     setRatingIdx(0);
     setSortBy("rating-asc");


### PR DESCRIPTION
## Summary
- Removes the invalid `setDebouncedSearch("")` call from `clearAll` on the Practice page.
- Keeps the existing filter reset behavior for search, tags, rating, sort, and page.

## Linked issue
- Fixes #161

## Problem
Clicking **Clear All** can call `setDebouncedSearch`, but that setter is not defined in `PracticePage.jsx`, causing a `ReferenceError`.

## Fix
`clearAll` now resets the source `searchQuery` state only. The existing debounced search effect then updates `debouncedSearch` through the normal path.

## Validation
- `npm ci`
- `npx eslint src/pages/PracticePage.jsx`
- `npm run build`
- Browser click-through: **Clear All** and **Clear All Filters** no longer produce console errors.

## Risk notes
- Scope is one line in `frontend/src/pages/PracticePage.jsx`.
- Full repo lint has unrelated existing failures outside this file; targeted lint for `PracticePage.jsx` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on the Practice page where the search input field was not being properly cleared when users clicked to reset all filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->