### PR TITLE
fix: remove invalid setDebouncedSearch call in clearAll

### DIFF
--- a/frontend/src/pages/PracticePage.jsx
+++ b/frontend/src/pages/PracticePage.jsx
@@ -332,7 +332,6 @@ export default function PracticePage() {
 
   const clearAll = () => {
     setSearchQuery("");
-    setDebouncedSearch("");
     setSelectedTags([]);
     setRatingIdx(0);
     setSortBy("rating-asc");


### PR DESCRIPTION
# 📌 Pull Request Summary

## 🔗 Related Issue
Closes #161 

---

## 📝 Description
Fixed a `ReferenceError` crash that occurred when clicking the "Clear All" 
or "Clear All Filters" button on the Practice Page. The page was becoming 
completely unresponsive to filter clearing.

### Changes Made
* Removed invalid `setDebouncedSearch("")` call from `clearAll()` in `PracticePage.jsx`

### Motivation
The `useDebounce` hook returns only a debounced read-only value — it never 
exposes a setter. Calling `setDebouncedSearch("")` caused JavaScript to throw 
a `ReferenceError` immediately, which halted execution and prevented all 
the reset logic below it (`setSelectedTags`, `setRatingIdx`, `setSortBy`, 
`setPage`) from running. Removing this one invalid line is sufficient — 
`debouncedSearch` automatically follows `searchQuery` after the 300ms 
debounce timer.

---

## 🚀 Type of Change
* [x] Bug Fix

---

## 🧪 Testing

### Verification
* [x] Tested Locally
* [x] Existing Tests Passed
* [ ] New Tests Added
* [ ] No Testing Required

### Test Details
- Navigated to `/practice` page
- Typed a search query and applied tag/rating filters
- Clicked **"Clear All"** chip → all filters reset, zero console errors ✅
- Clicked **"Clear All Filters"** in the empty-results state → works correctly ✅
- Verified normal search box typing → debounce behavior unaffected ✅
- Checked DevTools Console → no `ReferenceError` present ✅

---

## 📸 Screenshots / Demo (If Applicable)
<!-- Attach a short screen recording or screenshot of Clear All working 
without errors in the Console tab — strongly recommended -->

---

## ✅ Checklist
* [x] I have read and followed the contribution guidelines.
* [x] I have self-reviewed my changes.
* [x] My changes are limited to the scope of this issue.
* [x] Documentation has been updated where necessary.
* [x] No unnecessary files or unrelated changes have been included.
* [x] The related issue has been linked correctly.
* [x] All applicable testing and validation steps have been completed.

---

## 📚 Additional Notes
Two buttons both call `clearAll()` and were both broken by this bug:
- The inline **"Clear All"** chip 
- The **"Clear All Filters"** button in the empty-results state 
Both are fixed by this single change. No regression to debounce behaviour 
during normal typing. No backend changes required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the filter clearing functionality to properly reset all filter controls including search, tags, rating filters, sort order, and pagination to their default states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->