### PR TITLE
Fix: Prevent revoked refresh tokens from bypassing silent refresh

### DIFF
--- a/server/middlewares/authMiddleware.js
+++ b/server/middlewares/authMiddleware.js
@@ -1,6 +1,7 @@
 import { verifyToken, verifyRefreshToken, generateAccessToken, setAccessTokenCookie } from "../utils/tokenHelper.js";
 import User from "../models/User.js";
 import ApiError from "../utils/ApiError.js";
+import bcrypt from "bcryptjs";
 
 /**
  * Auth Middleware
@@ -44,19 +45,50 @@ const authMiddleware = async (req, res, next) => {
         try {
           const refreshDecoded = verifyRefreshToken(req.cookies.refreshToken);
           const userId = refreshDecoded.userId || refreshDecoded.id || refreshDecoded._id;
-          const newAccessToken = generateAccessToken({
-            userId,
-            email: refreshDecoded.email,
-            role: refreshDecoded.role
+          // Validate refresh token against stored hash
+          const refreshUser = await User.findById(userId).select("+security.refreshTokenHash");
+          if (!refreshUser) {
+            throw new ApiError(401, "User not found.");
+          }
+          const storedHash = refreshUser.security?.refreshTokenHash;
+          if (!storedHash) {
+            throw new ApiError(
+               401,
+            "Session has been revoked. Please log in again."
+            );
+          }
+          const isValid = await bcrypt.compare(
+            req.cookies.refreshToken,
+            storedHash
+            );
+
+          if (!isValid) {
+            throw new ApiError(
+            401,
+            "Invalid session. Please log in again."
+            );
+          }
+          const newAccessToken = generateAccessToken({userId: refreshUser._id, email: refreshUser.email, role: refreshUser.role
           });
-          // Set only the new access token cookie — refresh token stays unchanged.
-          // Cookie options are centralised in setAccessTokenCookie (tokenHelper.js).
+
+          // Set only the new access token cookie
           setAccessTokenCookie(res, newAccessToken);
-          decoded = { userId, email: refreshDecoded.email, role: refreshDecoded.role };
-        } catch {
-          throw new ApiError(401, "Session expired. Please log in again.");
-        }
-      } else {
+
+          decoded = {userId: refreshUser._id ,email: refreshUser.email,  role: refreshUser.role
+        };
+        
+        } catch (error) {
+          if (error instanceof ApiError) {
+          throw error;
+          }
+
+          throw new ApiError(
+            401,
+            "Session expired. Please log in again."
+          );
+
+      } 
+      }else {
         throw new ApiError(401, "Invalid or expired token.");
       }
     }

--- a/server/middlewares/authMiddleware.js
+++ b/server/middlewares/authMiddleware.js
@@ -94,6 +94,9 @@ const authMiddleware = async (req, res, next) => {
             role: refreshUser.role
           };
         
+          if (refreshUser.security) {
+            refreshUser.security.refreshTokenHash = undefined;
+          }
           prefetchedUser = refreshUser;
 
         } catch (error) {

--- a/server/middlewares/authMiddleware.js
+++ b/server/middlewares/authMiddleware.js
@@ -1,4 +1,4 @@
-import { verifyToken, verifyRefreshToken, generateAccessToken, setAccessTokenCookie } from "../utils/tokenHelper.js";
+import { verifyToken, verifyRefreshToken, generateAccessToken, setAccessTokenCookie, clearAuthCookies } from "../utils/tokenHelper.js";
 import User from "../models/User.js";
 import ApiError from "../utils/ApiError.js";
 import bcrypt from "bcryptjs";
@@ -36,6 +36,8 @@ const authMiddleware = async (req, res, next) => {
       throw new ApiError(401, "Access denied. No token provided.");
     }
 
+    let prefetchedUser = null;
+ 
     let decoded;
     try {
       decoded = verifyToken(token);
@@ -47,79 +49,93 @@ const authMiddleware = async (req, res, next) => {
           const userId = refreshDecoded.userId || refreshDecoded.id || refreshDecoded._id;
           // Validate refresh token against stored hash
           const refreshUser = await User.findById(userId).select("+security.refreshTokenHash");
+          
           if (!refreshUser) {
             throw new ApiError(401, "User not found.");
           }
+          
           const storedHash = refreshUser.security?.refreshTokenHash;
           if (!storedHash) {
-            throw new ApiError(
-               401,
-            "Session has been revoked. Please log in again."
-            );
+            clearAuthCookies(res);
+            throw new ApiError(401, "Session has been revoked. Please log in again.");
           }
+          
           const isValid = await bcrypt.compare(
             req.cookies.refreshToken,
             storedHash
-            );
-
+          );
+          
           if (!isValid) {
+            await User.findByIdAndUpdate(userId, {
+              $unset: { "security.refreshTokenHash": "" }
+            });
+            
+            clearAuthCookies(res);
+            
             throw new ApiError(
             401,
             "Invalid session. Please log in again."
             );
           }
-          const newAccessToken = generateAccessToken({userId: refreshUser._id, email: refreshUser.email, role: refreshUser.role
+          const newAccessToken = generateAccessToken({
+            userId: refreshUser._id,
+            email: refreshUser.email,
+            role: refreshUser.role
           });
 
           // Set only the new access token cookie
           setAccessTokenCookie(res, newAccessToken);
 
-          decoded = {userId: refreshUser._id ,email: refreshUser.email,  role: refreshUser.role
-        };
+          decoded = {
+            userId: refreshUser._id,
+            email: refreshUser.email,
+            role: refreshUser.role
+         };
         
+          prefetchedUser = refreshUser;
+
         } catch (error) {
           if (error instanceof ApiError) {
-          throw error;
+            throw error;
           }
 
           throw new ApiError(
             401,
             "Session expired. Please log in again."
           );
-
-      } 
-      }else {
-        throw new ApiError(401, "Invalid or expired token.");
+        } 
+      } else {
+          throw new ApiError(401, "Invalid or expired token.");
+        }
       }
-    }
 
-    const userId = decoded.userId || decoded.id || decoded._id;
+      const userId = decoded.userId || decoded.id || decoded._id;
 
-    if (!userId) {
-      throw new ApiError(401, "Invalid token payload.");
-    }
+      if (!userId) {
+        throw new ApiError(401, "Invalid token payload.");
+      }
 
-    const user = await User.findById(userId).select("-password");
+      const user = prefetchedUser ?? await User.findById(userId).select("-password");
+      if (!user) {
+        throw new ApiError(401, "User not found or account deleted.");
+      }
 
-    if (!user) {
-      throw new ApiError(401, "User not found or account deleted.");
-    }
+      req.user = user;
+      next();
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return res.status(error.statusCode).json({
+          success: false,
+          message: error.message
+        });
+      }
 
-    req.user = user;
-    next();
-  } catch (error) {
-    if (error instanceof ApiError) {
-      return res.status(error.statusCode).json({
+      return res.status(401).json({
         success: false,
-        message: error.message
+        message: "Invalid or expired token."
       });
+    
     }
-
-    return res.status(401).json({
-      success: false,
-      message: "Invalid or expired token."
-    });
-  }
-};
+  };
 
 export default authMiddleware;

--- a/server/middlewares/authMiddleware.js
+++ b/server/middlewares/authMiddleware.js
@@ -14,6 +14,7 @@ import bcrypt from "bcryptjs";
  * we transparently issue a new access token cookie (silent refresh).
  */
 const authMiddleware = async (req, res, next) => {
+
   try {
     let token = null;
     let tokenSource = null;
@@ -47,6 +48,7 @@ const authMiddleware = async (req, res, next) => {
         try {
           const refreshDecoded = verifyRefreshToken(req.cookies.refreshToken);
           const userId = refreshDecoded.userId || refreshDecoded.id || refreshDecoded._id;
+
           // Validate refresh token against stored hash
           const refreshUser = await User.findById(userId).select("+security.refreshTokenHash");
           
@@ -73,8 +75,8 @@ const authMiddleware = async (req, res, next) => {
             clearAuthCookies(res);
             
             throw new ApiError(
-            401,
-            "Invalid session. Please log in again."
+              401,
+              "Invalid session. Please log in again."
             );
           }
           const newAccessToken = generateAccessToken({
@@ -90,7 +92,7 @@ const authMiddleware = async (req, res, next) => {
             userId: refreshUser._id,
             email: refreshUser.email,
             role: refreshUser.role
-         };
+          };
         
           prefetchedUser = refreshUser;
 
@@ -105,9 +107,9 @@ const authMiddleware = async (req, res, next) => {
           );
         } 
       } else {
-          throw new ApiError(401, "Invalid or expired token.");
-        }
+        throw new ApiError(401, "Invalid or expired token.");
       }
+    }
 
       const userId = decoded.userId || decoded.id || decoded._id;
 
@@ -133,8 +135,7 @@ const authMiddleware = async (req, res, next) => {
       return res.status(401).json({
         success: false,
         message: "Invalid or expired token."
-      });
-    
+     });
     }
   };
 


### PR DESCRIPTION
## Fix: Prevent revoked refresh tokens from bypassing silent refresh

### Related Issue

Closes #208 

### Summary

This PR fixes a security issue in the authentication middleware where revoked refresh tokens could still be used during the silent refresh flow.

### Problem

The `/api/auth/refresh` endpoint correctly validates refresh tokens against the stored `security.refreshTokenHash` before issuing new tokens.

However, the silent refresh logic inside `authMiddleware.js` only verified the JWT signature using `verifyRefreshToken()` and did not validate the presented refresh token against the hash stored in the database.

As a result, if an access token expired and a revoked refresh token was still present, the middleware could silently authenticate the request and issue a new access token.

### Root Cause

The silent refresh path performed:

* Refresh token JWT verification
* User lookup

but skipped:

* Validation against `security.refreshTokenHash`

This created inconsistent behavior between:

* `/api/auth/refresh`
* Silent refresh inside `authMiddleware`

### Solution

Added refresh token hash validation to the silent refresh flow.

The middleware now:

1. Retrieves the user along with `security.refreshTokenHash`
2. Verifies that a stored hash exists
3. Validates the incoming refresh token using `bcrypt.compare()`
4. Rejects revoked or invalid sessions with a `401 Unauthorized` response

The new access token is only issued when the refresh token successfully passes hash validation.

### Verification

To reproduce and validate the issue, I created a local regression test covering the silent refresh flow.

#### Test Case 1: Revoked Refresh Token

Setup:

* Created a test user
* Generated a refresh token
* Removed `security.refreshTokenHash` to simulate logout/session revocation
* Sent a request with:

  * an expired access token
  * the revoked refresh token

Result before fix:

* Response: `200 OK`
* Silent refresh incorrectly authenticated the request

Result after fix:

* Response: `401 Unauthorized`
* Revoked session correctly rejected

#### Test Case 2: Valid Refresh Token

Setup:

* Created a test user
* Stored a valid refresh token hash
* Sent a request with:

  * an expired access token
  * a valid refresh token

Result:

* Response: `200 OK`
* Silent refresh succeeds as expected

### Files Changed

* `server/middlewares/authMiddleware.js`

### Impact

This change ensures refresh token revocation is consistently enforced across all authentication flows and prevents revoked refresh tokens from being used to regain access through silent refresh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Strengthened session token refresh by validating refresh tokens against the stored hash to prevent unauthorized token reissuance  
- Improved silent-refresh failure handling, clearing auth cookies and returning clearer “session expired” guidance to log in again  
- Enhanced authentication state verification to make session management more reliable across the application
<!-- end of auto-generated comment: release notes by coderabbit.ai -->