### PR TITLE
style: replace Inter with Space Grotesk across full website

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,11 +1,15 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300..700&display=swap');
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
 @theme {
-  --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans: 'Space Grotesk', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+*, *::before, *::after {
+  font-family: 'Space Grotesk', sans-serif;
 }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: 'Space Grotesk', sans-serif;
 }


### PR DESCRIPTION
# 📌 Pull Request Summary

## 📝 Description

Replaced the Inter font with Space Grotesk across the entire CodeLens website for a more modern and distinctive typographic identity.

### Changes Made

* Replaced Google Fonts import from Inter to Space Grotesk (weight range 300–700)
* Updated `--font-sans` in Tailwind v4 `@theme` block so all Tailwind font utilities use Space Grotesk
* Added universal `*` selector override to ensure Space Grotesk applies even to components with hardcoded font styles

### Motivation

Inter was the default placeholder font. Space Grotesk gives CodeLens a stronger, more technical, and modern visual identity that better suits a developer intelligence platform.

---

## 🚀 Type of Change

* [x] Enhancement

---

## 🧪 Testing

### Verification

* [x] Tested Locally

### Test Details

Verified locally that Space Grotesk loads and renders correctly across all pages including the dashboard, APEX AI workspace, Codeforces page, and landing page.

---

## ✅ Checklist

* [x] I have read and followed the contribution guidelines.
* [x] I have self-reviewed my changes.
* [x] My changes are limited to the scope of this issue.
* [x] Documentation has been updated where necessary.
* [x] No unnecessary files or unrelated changes have been included.
* [x] The related issue has been linked correctly.
* [x] All applicable testing and validation steps have been completed.

---

## 📚 Additional Notes

This change touches only `frontend/src/index.css`. No component files were modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the global font throughout the application from Inter to Space Grotesk, affecting typography across all pages and components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->