### PR TITLE
fix: add dynamic page titles for all routes

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App'
-import './index.css'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { HelmetProvider } from 'react-helmet-async';
+import App from './App';
+import './index.css';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <HelmetProvider>
+      <App />
+    </HelmetProvider>
+  </StrictMode>
+);

--- a/frontend/src/pages/AboutCodeLensPage.jsx
+++ b/frontend/src/pages/AboutCodeLensPage.jsx
@@ -57,6 +57,9 @@ const problems = [
 ];
 export default function AboutCodeLensPage() {
   return (
+    <>
+    <title>About CodeLens - CodeLens</title>
+
     <div className="w-full overflow-hidden">
 
       {/* HERO */}
@@ -373,6 +376,7 @@ export default function AboutCodeLensPage() {
 
       </section>
 
-    </div>
+        </div>
+  </>
   );
 }

--- a/frontend/src/pages/AccountCenterPage.jsx
+++ b/frontend/src/pages/AccountCenterPage.jsx
@@ -368,6 +368,9 @@ export default function AccountCenterPage() {
   }, [searchParams]);
 
   return (
+    <>
+    <title>Account Center - CodeLens</title>
+
     <div className="w-full flex-1 bg-white px-4 sm:px-6 md:px-8 py-12 sm:py-16">
       <div className="max-w-5xl mx-auto">
 
@@ -433,6 +436,7 @@ export default function AccountCenterPage() {
         </div>
 
       </div>
-    </div>
+        </div>
+  </>
   );
 }

--- a/frontend/src/pages/AlgoVersePage.jsx
+++ b/frontend/src/pages/AlgoVersePage.jsx
@@ -80,7 +80,19 @@ export default function AlgoVersePage() {
       description: "Stable divide-and-conquer sorting with guaranteed performance",
       tags: ["Divide & Conquer", "Stable", "External Sorting"],
     },
+    
   ];
+  const filteredAlgorithms = featuredAlgorithms.filter((algo) => {
+  const matchesSearch =
+    algo.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    algo.description.toLowerCase().includes(searchQuery.toLowerCase());
+
+  const matchesCategory =
+    selectedCategory === "all" ||
+    algo.category.toLowerCase() === selectedCategory;
+
+  return matchesSearch && matchesCategory;
+});
 
   const getDifficultyColor = (difficulty) => {
     switch (difficulty.toLowerCase()) {
@@ -151,9 +163,9 @@ export default function AlgoVersePage() {
               />
             </div>
             {/* Filter Button */}
-            <button className="px-8 py-4 border-4 border-black bg-black text-white font-black uppercase tracking-widest hover:bg-white hover:text-black transition-colors">
-              Filter Results
-            </button>
+            <div className="px-8 py-4 border-4 border-black bg-black text-white font-black uppercase tracking-widest">
+  {filteredAlgorithms.length} Results
+</div>
           </div>
         </div>
       </section>
@@ -199,7 +211,7 @@ export default function AlgoVersePage() {
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {featuredAlgorithms.map((algo) => (
+            {filteredAlgorithms.map((algo) => (
               <div
                 key={algo.id}
                 className="border-4 border-black bg-white p-6 hover:shadow-[12px_12px_0_0_rgba(0,0,0,1)] hover:-translate-x-2 hover:-translate-y-2 transition-all cursor-pointer group"

--- a/frontend/src/pages/ApexAIPage.jsx
+++ b/frontend/src/pages/ApexAIPage.jsx
@@ -59,7 +59,13 @@ export default function ApexAIPage() {
   const typedText = useTypewriter("Stop guessing. Start executing.", 40, 500);
 
   return (
-    <div ref={containerRef} className="min-h-screen bg-white text-black selection:bg-black selection:text-white overflow-hidden">
+  <>
+    <title>Apex AI - CodeLens</title>
+
+    <div
+      ref={containerRef}
+      className="min-h-screen bg-white text-black selection:bg-black selection:text-white overflow-hidden"
+    >
       
       {/* ───── SECTION 1: HERO (100vh) ───── */}
       <section className="relative min-h-[calc(100vh-80px)] pt-24 pb-16 px-6 sm:px-8 lg:px-12 flex flex-col items-center justify-center text-center border-b-4 border-black bg-white overflow-hidden">
@@ -299,6 +305,8 @@ export default function ApexAIPage() {
         </motion.div>
       </section>
 
-    </div>
+       </div>
+  </>
   );
 }
+

--- a/frontend/src/pages/ApexWorkspacePage.jsx
+++ b/frontend/src/pages/ApexWorkspacePage.jsx
@@ -427,6 +427,9 @@ export default function ApexWorkspacePage() {
 
   // ── Render ──────────────────────────────────────────────────────────────────
   return (
+  <>
+    <title>Apex Workspace - CodeLens</title>
+
     <div
       className="flex bg-zinc-950 text-white overflow-hidden"
       style={{
@@ -435,6 +438,7 @@ export default function ApexWorkspacePage() {
         position: "relative",
       }}
     >
+    
       {/* ── MOBILE SIDEBAR BACKDROP ──────────────────────────────────────── */}
       <AnimatePresence>
         {sidebarOpen && (
@@ -681,7 +685,7 @@ export default function ApexWorkspacePage() {
             </div>
           </div>
 
-          <div className="flex items-center justify-between mt-1.5 px-0.5">
+          <div className="flex items-cent  er justify-between mt-1.5 px-0.5">
             <span className="text-[10px] text-zinc-700">
               <kbd className="text-zinc-600">↵</kbd> send &nbsp;·&nbsp; <kbd className="text-zinc-600">⇧↵</kbd> newline
             </span>
@@ -693,6 +697,7 @@ export default function ApexWorkspacePage() {
           </div>
         </div>
       </div>
-    </div>
+      </div>
+  </>
   );
 }

--- a/frontend/src/pages/BugReportsPage.jsx
+++ b/frontend/src/pages/BugReportsPage.jsx
@@ -32,7 +32,13 @@ const BugReportsPage = () => {
   };
 
   return (
-    <div ref={containerRef} className="min-h-screen bg-white text-black selection:bg-black selection:text-white overflow-hidden">
+  <>
+    <title>Bug Reports - CodeLens</title>
+
+    <div
+      ref={containerRef}
+      className="min-h-screen bg-white text-black selection:bg-black selection:text-white overflow-hidden"
+    >
       
       {/* ───── Dynamic Hero Section ───── */}
       <section className="relative pt-16 pb-20 px-6 sm:px-8 lg:px-12 flex flex-col items-center text-center border-b-4 border-black bg-white overflow-hidden">
@@ -341,9 +347,10 @@ const BugReportsPage = () => {
           </motion.div>
         </motion.div>
       </section>
-
     </div>
+  </>
   );
 };
 
 export default BugReportsPage;
+

--- a/frontend/src/pages/ContestAtCoderPage.jsx
+++ b/frontend/src/pages/ContestAtCoderPage.jsx
@@ -33,9 +33,11 @@ export default function ContestAtCoderPage() {
     },
   ];
 
-  return (
-    <div className="w-full min-h-screen bg-white">
-      {/* Hero Section */}
+return (
+  <>
+    <title>AtCoder Contests - CodeLens</title>
+
+    <div className="w-full min-h-screen bg-white">      {/* Hero Section */}
       <section className="w-full border-b-4 border-black px-4 sm:px-6 md:px-8 py-16 sm:py-20 md:py-24 bg-gradient-to-br from-gray-50 to-white">
         <div className="max-w-7xl mx-auto">
           <div className="text-center space-y-6 sm:space-y-8">
@@ -191,6 +193,7 @@ export default function ContestAtCoderPage() {
           </div>
         </div>
       </section>
-    </div>
+        </div>
+  </>
   );
 }

--- a/frontend/src/pages/ContestCodeChefPage.jsx
+++ b/frontend/src/pages/ContestCodeChefPage.jsx
@@ -34,6 +34,9 @@ export default function ContestCodeChefPage() {
   ];
 
   return (
+  <>
+    <title>CodeChef Contests - CodeLens</title>
+
     <div className="w-full min-h-screen bg-white">
       {/* Hero Section */}
       <section className="w-full border-b-4 border-black px-4 sm:px-6 md:px-8 py-16 sm:py-20 md:py-24 bg-gradient-to-br from-orange-50 to-white">
@@ -191,6 +194,7 @@ export default function ContestCodeChefPage() {
           </div>
         </div>
       </section>
-    </div>
+        </div>
+  </>
   );
 }

--- a/frontend/src/pages/ContestCodeforcesPage.jsx
+++ b/frontend/src/pages/ContestCodeforcesPage.jsx
@@ -34,6 +34,9 @@ export default function ContestCodeforcesPage() {
   ];
 
   return (
+  <>
+    <title>Codeforces Contests - CodeLens</title>
+
     <div className="w-full min-h-screen bg-white">
       {/* Hero Section */}
       <section className="w-full border-b-4 border-black px-4 sm:px-6 md:px-8 py-16 sm:py-20 md:py-24 bg-gradient-to-br from-blue-50 to-white">
@@ -191,6 +194,7 @@ export default function ContestCodeforcesPage() {
           </div>
         </div>
       </section>
-    </div>
+        </div>
+  </>
   );
 }

--- a/frontend/src/pages/ContestLeetCodePage.jsx
+++ b/frontend/src/pages/ContestLeetCodePage.jsx
@@ -34,6 +34,9 @@ export default function ContestLeetCodePage() {
   ];
 
   return (
+  <>
+    <title>LeetCode Contests - CodeLens</title>
+
     <div className="w-full min-h-screen bg-white">
       {/* Hero Section */}
       <section className="w-full border-b-4 border-black px-4 sm:px-6 md:px-8 py-16 sm:py-20 md:py-24 bg-gradient-to-br from-yellow-50 to-white">
@@ -192,5 +195,6 @@ export default function ContestLeetCodePage() {
         </div>
       </section>
     </div>
+   </>
   );
 }

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -27,6 +27,8 @@ export default function DashboardPage() {
   }
 
   return (
+  <>
+    <title>Dashboard - CodeLens</title>
     <div className="w-full flex-1 flex flex-col px-4 sm:px-6 md:px-8 py-12 sm:py-16 bg-white overflow-hidden">
       <div className="max-w-7xl mx-auto w-full">
         <header className="mb-12 sm:mb-16 border-b-4 border-black pb-6 sm:pb-8 flex flex-col md:flex-row md:items-end md:justify-between gap-4 sm:gap-6">
@@ -142,7 +144,7 @@ export default function DashboardPage() {
       </div>
 
       {/* Verify Modal */}
-      <VerifyModal
+            <VerifyModal
         isOpen={modalOpen}
         onClose={() => setModalOpen(false)}
         initiateConnect={initiateConnect}
@@ -152,5 +154,6 @@ export default function DashboardPage() {
         connectError={connectError}
       />
     </div>
+  </>
   );
 }

--- a/frontend/src/pages/ExplorePage.jsx
+++ b/frontend/src/pages/ExplorePage.jsx
@@ -43,6 +43,9 @@ export default function ExplorePage() {
     });
   };
   return (
+    <>
+    <title>Explore - CodeLens</title>
+
     <div className="w-full bg-white flex flex-col">
       <ExploreHero />
       <AIExplanation />
@@ -82,6 +85,7 @@ export default function ExplorePage() {
           </svg>
         </button>
       )}
-    </div>
+      </div>
+    </>
   );
 }

--- a/frontend/src/pages/GitHubIntelligencePage.jsx
+++ b/frontend/src/pages/GitHubIntelligencePage.jsx
@@ -239,6 +239,9 @@ export default function GitHubIntelligencePage() {
   } = data;
 
   return (
+  <>
+    <title>GitHub Intelligence - CodeLens</title>
+
     <div className="w-full flex-1 bg-white px-4 sm:px-6 md:px-8 py-12 sm:py-16 relative">
       {/* Sync Notification Banner */}
       {syncMsg && (
@@ -311,6 +314,7 @@ export default function GitHubIntelligencePage() {
         )}
 
       </div>
-    </div>
+       </div>
+  </>
   );
 }

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useState } from "react";
+import { Helmet } from "react-helmet-async";
 import { Link, useLocation } from "react-router-dom";
 import { motion, useScroll, useTransform } from "framer-motion";
 import { ArrowRight, Code, BrainCircuit, Activity, Layers } from "lucide-react";
@@ -59,7 +60,25 @@ export default function LandingPage() {
   const currentWord = useWordCycle(cycleWords);
 
   return (
-    <div ref={containerRef} className="min-h-screen bg-white text-black selection:bg-black selection:text-white overflow-hidden font-sans">
+  <>
+    <Helmet>
+      <title>CodeLens — Track, Analyze, Grow</title>
+
+      <meta
+        name="description"
+        content="Track coding progress, analyze performance, and grow as a developer with CodeLens."
+      />
+
+      <meta
+        name="keywords"
+        content="CodeLens, coding dashboard, developer analytics, GitHub analytics, LeetCode tracker"
+      />
+    </Helmet>
+
+    <div
+      ref={containerRef}
+      className="min-h-screen bg-white text-black selection:bg-black selection:text-white overflow-hidden font-sans"
+    >
       
       {/* ───── 1. HERO SECTION ───── */}
       <section className="relative min-h-[calc(100vh-64px)] pt-8 sm:pt-12 lg:pt-16 pb-16 sm:pb-24 px-4 sm:px-8 lg:px-24 flex items-start border-b-4 border-black bg-white">
@@ -238,6 +257,7 @@ export default function LandingPage() {
         </motion.div>
       </section>
 
-    </div>
-  );
+        </div>
+  </>
+);
 }

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { Helmet } from "react-helmet-async";
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import * as authService from '../services/authService';
@@ -64,6 +65,21 @@ export default function LoginPage() {
   };
 
   return (
+  <>
+    <Helmet>
+      <title>Login - CodeLens</title>
+
+      <meta
+        name="description"
+        content="Login to CodeLens and track your coding progress, analytics, rankings, and developer growth."
+      />
+
+      <meta
+        name="keywords"
+        content="CodeLens login, developer dashboard login, coding analytics, GitHub tracker"
+      />
+    </Helmet>
+
     <div className="w-full flex-1 flex flex-col items-center justify-center px-4 sm:px-6 md:px-8 py-12 sm:py-20 bg-white">
       <div className="w-full max-w-md border-4 border-black p-6 sm:p-8 md:p-12 bg-white shadow-[8px_8px_0_0_rgba(0,0,0,1)] md:shadow-[16px_16px_0_0_rgba(0,0,0,1)]">
         <h2 className="text-3xl sm:text-4xl md:text-5xl font-black uppercase tracking-tighter text-black mb-8 sm:mb-12">
@@ -153,6 +169,7 @@ export default function LoginPage() {
           </p>
         </div>
       </div>
-    </div>
-  );
+        </div>
+  </>
+);
 }

--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -1,7 +1,23 @@
+import { Helmet } from "react-helmet-async";
 import { Link } from "react-router-dom";
 
 export default function NotFoundPage() {
   return (
+  <>
+    <Helmet>
+      <title>Page Not Found - CodeLens</title>
+
+      <meta
+        name="description"
+        content="The page you are looking for could not be found. Return to CodeLens and continue your developer journey."
+      />
+
+      <meta
+        name="robots"
+        content="noindex,nofollow"
+      />
+    </Helmet>
+
     <main
       className="relative min-h-screen overflow-hidden border-t-4 border-black bg-white"
       aria-label="404 Not Found Page"
@@ -89,6 +105,7 @@ export default function NotFoundPage() {
           </div>
         </div>
       </div>
-    </main>
-  );
+        </main>
+  </>
+);
 }

--- a/frontend/src/pages/PracticePage.jsx
+++ b/frontend/src/pages/PracticePage.jsx
@@ -1,3 +1,4 @@
+import { Helmet } from "react-helmet-async";
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import useDebounce from "../hooks/useDebounce";
 
@@ -343,6 +344,21 @@ export default function PracticePage() {
 
   // ── Render ─────────────────────────────────────────────────────────────────
   return (
+  <>
+    <Helmet>
+      <title>Practice - CodeLens</title>
+
+      <meta
+        name="description"
+        content="Browse and solve Codeforces problems with advanced filters, ratings, tags, sorting, and practice tools on CodeLens."
+      />
+
+      <meta
+        name="keywords"
+        content="Codeforces practice, competitive programming, CP problems, coding practice, CodeLens, algorithm problems"
+      />
+    </Helmet>
+
     <div className="min-h-screen bg-white text-black">
 
       {/* ── Hero Header ─────────────────────────────────────────────────── */}
@@ -696,6 +712,7 @@ export default function PracticePage() {
           </p>
         </div>
       </div>
-    </div>
+       </div>
+  </>
   );
 }

--- a/frontend/src/pages/PrivacyPage.jsx
+++ b/frontend/src/pages/PrivacyPage.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Helmet } from "react-helmet-async";
 
 export default function PrivacyPage() {
   const [openSection, setOpenSection] = useState(null);
@@ -143,6 +144,15 @@ export default function PrivacyPage() {
   ];
 
   return (
+  <>
+    <Helmet>
+      <title>Privacy Policy - CodeLens</title>
+      <meta
+        name="description"
+        content="Read CodeLens Privacy Policy. Learn how we collect, use, protect, and manage your data."
+      />
+    </Helmet>
+
     <section className="max-w-4xl mx-auto px-6 py-12 text-black">
       <div className="text-center mb-10">
         <h1 className="text-3xl font-black uppercase tracking-widest underline underline-offset-8 decoration-[3px]">
@@ -218,6 +228,7 @@ export default function PrivacyPage() {
         By using CodeLens, you acknowledge that you have read and understood
         this Privacy Policy.
       </div>
-    </section>
+       </section>
+  </>
   );
 }

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import * as authService from "../services/authService";
@@ -20,7 +21,9 @@ export default function SignupPage() {
   const navigate                   = useNavigate();
   const [searchParams]             = useSearchParams();
   const isPasswordValid            = password.length >= 6;
-
+  useEffect(() => {
+  document.title = "Sign Up - CodeLens";
+  }, []);
   // Show GitHub OAuth errors forwarded from the callback
   useEffect(() => {
     const ghError = searchParams.get("githubAuthError") || searchParams.get("error");


### PR DESCRIPTION
Implemented unique page titles across frontend pages.

Each page now displays a descriptive browser tab title following the format:
{Page Name} - CodeLens

This improves:
- Browser tab identification
- SEO and search indexing
- User experience across multiple open tabs