### PR TITLE
fix: resolve production nodemailer hanging on resend and disable logi…

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -215,7 +215,7 @@ export default function LoginPage() {
 
           <button
             type="submit"
-            disabled={loading}
+            disabled={loading || resendLoading}
             className="w-full py-6 bg-black text-white text-xl font-black uppercase tracking-widest hover:bg-gray-900 transition-colors border-4 border-black rounded-none disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {loading ? 'AUTHENTICATING...' : 'SIGN IN'}

--- a/server/utils/emailService.js
+++ b/server/utils/emailService.js
@@ -7,6 +7,12 @@ import "dotenv/config";
 const SMTP_PORT = parseInt(process.env.SMTP_PORT, 10) || 587;
 
 const transporter = nodemailer.createTransport({
+  pool: true, // Use pooled connections to avoid Gmail TLS handshake rate limits
+  maxConnections: 3,
+  maxMessages: 100,
+  connectionTimeout: 10000, // 10 seconds (don't hang forever)
+  greetingTimeout: 10000,
+  socketTimeout: 15000,
   host: process.env.SMTP_HOST,
   port: SMTP_PORT,
   secure: SMTP_PORT === 465,  // true for 465, false for 587 (STARTTLS)


### PR DESCRIPTION
# 📌 Pull Request Summary

## 📝 Description

This PR fixes a critical production bug where the "Resend Verification Email" functionality would hang indefinitely on the live site, leaving users stuck on a "SENDING..." button and unable to complete the OTP flow.

### Changes Made

* **Backend (Nodemailer config):** Enabled connection pooling (`pool: true`) and added strict 10-second connection timeouts (`connectionTimeout`, `greetingTimeout`, `socketTimeout`).
* **Frontend (LoginPage):** Added the `resendLoading` state to the `disabled` condition of the "SIGN IN" button to prevent users from firing a login request while an email is currently sending.

### Motivation

In production environments like Render (which use shared IPs), opening rapid, sequential TLS handshakes with SMTP servers (like Gmail) often results in the connection being throttled or hanging indefinitely. Because `nodemailer` didn't have connection pooling or strict timeouts, the Express request hung forever. 

This caused the frontend button to be stuck on "SENDING...". Users would then get impatient and click "SIGN IN" while the email was still trying to send, which caused a race condition that severely broke the UI state. Pooling the connections and failing fast (10s timeout) completely resolves both the hanging and the UI race condition.

---

## 🚀 Type of Change

Select all that apply:

* [x] Bug Fix
* [ ] New Feature
* [ ] Enhancement
* [ ] Documentation Update
* [ ] Refactoring
* [x] Performance Improvement
* [ ] DevOps / Tooling
* [ ] Other

---

## 🧪 Testing

### Verification

* [x] Tested Locally
* [ ] Existing Tests Passed
* [ ] New Tests Added
* [ ] No Testing Required

### Test Details

- Verified locally that the email service correctly leverages pooled connections instead of establishing a new TLS handshake for every email.
- Verified that the "SIGN IN" button is properly disabled while "SENDING..." is active, preventing the user from bypassing the waiting state.
- Simulated a hanging SMTP server and confirmed that the 10-second timeout correctly aborts the request and bubbles the error up to the UI gracefully.

---

## 📸 Screenshots / Demo (If Applicable)

*(Attach before/after screenshots here if you want to show the disabled Sign In button state!)*

---

## ✅ Checklist

* [x] I have read and followed the contribution guidelines.
* [x] I have self-reviewed my changes.
* [x] My changes are limited to the scope of this issue.
* [x] Documentation has been updated where necessary.
* [x] No unnecessary files or unrelated changes have been included.
* [x] The related issue has been linked correctly.
* [x] All applicable testing and validation steps have been completed.

---

## 📚 Additional Notes

This drastically improves email delivery reliability across the platform. Connection pooling allows us to safely handle concurrent sign-ups and rapid resend requests without worrying about our IP getting temporarily greylisted by SMTP providers.