### PR TITLE
feat: upcoming contests tracker for Codeforces with in-app reminders 

### DIFF
--- a/frontend/src/components/contests/ContestCountdown.jsx
+++ b/frontend/src/components/contests/ContestCountdown.jsx
@@ -1,0 +1,32 @@
+export default function ContestCountdown({ msUntilStart, isRunning }) {
+  if (isRunning) {
+    return (
+      <span className="font-black text-red-600 uppercase tracking-widest text-sm animate-pulse">
+        ● Live Now
+      </span>
+    );
+  }
+
+  if (msUntilStart <= 0) {
+    return (
+      <span className="font-black text-gray-400 uppercase tracking-widest text-sm">
+        Starting…
+      </span>
+    );
+  }
+
+  const totalSeconds = Math.floor(msUntilStart / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const pad = (n) => String(n).padStart(2, "0");
+
+  return (
+    <span className="font-black text-black tracking-widest text-sm sm:text-base tabular-nums">
+      {days > 0 && `${days}d `}
+      {pad(hours)}:{pad(minutes)}:{pad(seconds)}
+    </span>
+  );
+}

--- a/frontend/src/components/contests/ContestCountdown.jsx
+++ b/frontend/src/components/contests/ContestCountdown.jsx
@@ -1,16 +1,36 @@
-export default function ContestCountdown({ msUntilStart, isRunning }) {
+import { Radio } from "lucide-react";
+
+/**
+ * Renders a live "dd:hh:mm:ss" style countdown, or a running/finished label.
+ * `msUntilStart` and `isRunning` come from `useContests` and are recomputed
+ * every second from a single shared clock (see the hook) — this component
+ * just formats them, it doesn't run its own timer.
+ */
+export default function ContestCountdown({ msUntilStart, isRunning, compact = false }) {
   if (isRunning) {
     return (
-      <span className="font-black text-red-600 uppercase tracking-widest text-sm animate-pulse">
-        ● Live Now
+      <span
+        className={`flex items-center gap-1.5 font-black text-red-600 uppercase tracking-widest animate-pulse ${
+          compact ? "text-[10px]" : "text-sm"
+        }`}
+      >
+        <Radio size={compact ? 11 : 14} strokeWidth={3} />
+        Live Now
       </span>
     );
   }
 
+  // msUntilStart <= 0 with isRunning false means "now" is past both the start
+  // AND the end of the contest window — i.e. it has actually finished, not
+  // that it's about to start.
   if (msUntilStart <= 0) {
     return (
-      <span className="font-black text-gray-400 uppercase tracking-widest text-sm">
-        Starting…
+      <span
+        className={`font-black text-gray-400 uppercase tracking-widest ${
+          compact ? "text-[10px]" : "text-sm"
+        }`}
+      >
+        Ended
       </span>
     );
   }
@@ -24,7 +44,11 @@ export default function ContestCountdown({ msUntilStart, isRunning }) {
   const pad = (n) => String(n).padStart(2, "0");
 
   return (
-    <span className="font-black text-black tracking-widest text-sm sm:text-base tabular-nums">
+    <span
+      className={`font-black text-black tracking-widest tabular-nums ${
+        compact ? "text-[11px]" : "text-sm sm:text-base"
+      }`}
+    >
       {days > 0 && `${days}d `}
       {pad(hours)}:{pad(minutes)}:{pad(seconds)}
     </span>

--- a/frontend/src/components/contests/ContestReminderBell.jsx
+++ b/frontend/src/components/contests/ContestReminderBell.jsx
@@ -20,9 +20,10 @@ export default function ContestReminderBell() {
         const { data } = await getMyActiveReminders();
         if (cancelled) return;
         const now = Date.now();
-        const dueSoon = (data.data || []).filter(
-          (c) => c.startTimeSeconds * 1000 - now < DUE_SOON_WINDOW_MS
-        );
+        const dueSoon = (data.data || []).filter((c) => {
+          const msUntilStart = c.startTimeSeconds * 1000 - now;
+          return msUntilStart > 0 && msUntilStart < DUE_SOON_WINDOW_MS;
+        });
         setDueSoonCount(dueSoon.length);
       } catch {
         // Silent

--- a/frontend/src/components/contests/ContestReminderBell.jsx
+++ b/frontend/src/components/contests/ContestReminderBell.jsx
@@ -1,0 +1,56 @@
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext";
+import { getMyActiveReminders } from "../../services/contestService";
+
+const POLL_INTERVAL_MS = 60_000;
+const DUE_SOON_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export default function ContestReminderBell() {
+  const { isAuthenticated } = useAuth();
+  const [dueSoonCount, setDueSoonCount] = useState(0);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const { data } = await getMyActiveReminders();
+        if (cancelled) return;
+        const now = Date.now();
+        const dueSoon = (data.data || []).filter(
+          (c) => c.startTimeSeconds * 1000 - now < DUE_SOON_WINDOW_MS
+        );
+        setDueSoonCount(dueSoon.length);
+      } catch {
+        // Silent
+      }
+    };
+
+    poll();
+    const id = setInterval(poll, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [isAuthenticated]);
+
+  if (!isAuthenticated) return null;
+
+  return (
+    <Link
+      to="/contests/codeforces"
+      title="Upcoming contest reminders"
+      className="relative flex items-center justify-center w-8 h-8 text-zinc-500 hover:text-black transition-colors duration-150"
+    >
+      <span className="text-base leading-none">🔔</span>
+      {dueSoonCount > 0 && (
+        <span className="absolute -top-1 -right-1 flex items-center justify-center min-w-[16px] h-4 px-1 bg-red-600 text-white text-[10px] font-bold rounded-full leading-none">
+          {dueSoonCount > 9 ? "9+" : dueSoonCount}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/frontend/src/components/contests/ContestReminderBell.jsx
+++ b/frontend/src/components/contests/ContestReminderBell.jsx
@@ -1,11 +1,17 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
+import { Bell } from "lucide-react";
 import { useAuth } from "../../context/AuthContext";
 import { getMyActiveReminders } from "../../services/contestService";
 
-const POLL_INTERVAL_MS = 60_000;
-const DUE_SOON_WINDOW_MS = 24 * 60 * 60 * 1000;
+const POLL_INTERVAL_MS = 60_000; // 1 minute — reminders don't need second-level freshness
+const DUE_SOON_WINDOW_MS = 24 * 60 * 60 * 1000; // badge counts contests starting in <24h
 
+/**
+ * Small navbar bell badge — shows how many reminders the user has set for
+ * contests starting within the next 24 hours. Links through to the full
+ * tracker page. Renders nothing while there's nothing to show.
+ */
 export default function ContestReminderBell() {
   const { isAuthenticated } = useAuth();
   const [dueSoonCount, setDueSoonCount] = useState(0);
@@ -20,13 +26,12 @@ export default function ContestReminderBell() {
         const { data } = await getMyActiveReminders();
         if (cancelled) return;
         const now = Date.now();
-        const dueSoon = (data.data || []).filter((c) => {
-          const msUntilStart = c.startTimeSeconds * 1000 - now;
-          return msUntilStart > 0 && msUntilStart < DUE_SOON_WINDOW_MS;
-        });
+        const dueSoon = (data.data || []).filter(
+          (c) => c.startTimeSeconds * 1000 - now < DUE_SOON_WINDOW_MS
+        );
         setDueSoonCount(dueSoon.length);
       } catch {
-        // Silent
+        // Silent — the bell just won't update this cycle.
       }
     };
 
@@ -46,7 +51,7 @@ export default function ContestReminderBell() {
       title="Upcoming contest reminders"
       className="relative flex items-center justify-center w-8 h-8 text-zinc-500 hover:text-black transition-colors duration-150"
     >
-      <span className="text-base leading-none">🔔</span>
+      <Bell size={18} strokeWidth={2} />
       {dueSoonCount > 0 && (
         <span className="absolute -top-1 -right-1 flex items-center justify-center min-w-[16px] h-4 px-1 bg-red-600 text-white text-[10px] font-bold rounded-full leading-none">
           {dueSoonCount > 9 ? "9+" : dueSoonCount}

--- a/frontend/src/components/contests/UpcomingContestsList.jsx
+++ b/frontend/src/components/contests/UpcomingContestsList.jsx
@@ -17,8 +17,9 @@ function formatStartTime(startTimeSeconds) {
 }
 
 function formatDuration(durationSeconds) {
-  const hours = Math.floor(durationSeconds / 3600);
-  const minutes = Math.round((durationSeconds % 3600) / 60);
+  const totalMinutes = Math.round(durationSeconds / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
   return minutes ? `${hours}h ${minutes}m` : `${hours}h`;
 }
 

--- a/frontend/src/components/contests/UpcomingContestsList.jsx
+++ b/frontend/src/components/contests/UpcomingContestsList.jsx
@@ -18,8 +18,9 @@ function formatStartTime(startTimeSeconds) {
 }
 
 function formatDuration(durationSeconds) {
-  const hours = Math.floor(durationSeconds / 3600);
-  const minutes = Math.round((durationSeconds % 3600) / 60);
+  const totalMinutes = Math.round(durationSeconds / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
   return minutes ? `${hours}h ${minutes}m` : `${hours}h`;
 }
 

--- a/frontend/src/components/contests/UpcomingContestsList.jsx
+++ b/frontend/src/components/contests/UpcomingContestsList.jsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react";
 import { useNavigate, Link } from "react-router-dom";
+import { Bell, BellOff, Calendar, Timer } from "lucide-react";
 import { useAuth } from "../../context/AuthContext";
 import { useContests } from "../../hooks/useContests";
 import ContestCountdown from "./ContestCountdown";
@@ -17,12 +18,15 @@ function formatStartTime(startTimeSeconds) {
 }
 
 function formatDuration(durationSeconds) {
-  const totalMinutes = Math.round(durationSeconds / 60);
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
+  const hours = Math.floor(durationSeconds / 3600);
+  const minutes = Math.round((durationSeconds % 3600) / 60);
   return minutes ? `${hours}h ${minutes}m` : `${hours}h`;
 }
 
+/**
+ * @param {boolean} compact   - Dashboard-widget mode: top N contests, no filters.
+ * @param {number}  limit     - Max contests to show in compact mode.
+ */
 export default function UpcomingContestsList({ compact = false, limit = 3 }) {
   const { isAuthenticated } = useAuth();
   const navigate = useNavigate();
@@ -65,6 +69,16 @@ export default function UpcomingContestsList({ compact = false, limit = 3 }) {
     );
   }
 
+  if (!visibleContests.length) {
+    return (
+      <div className="border-4 border-black bg-white p-6 text-center">
+        <p className="font-black uppercase tracking-widest text-sm text-gray-500">
+          No upcoming Codeforces contests scheduled right now.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div>
       {!compact && (
@@ -91,56 +105,89 @@ export default function UpcomingContestsList({ compact = false, limit = 3 }) {
         </p>
       )}
 
-      {visibleContests.length === 0 ? (
-        <div className="border-4 border-black bg-white p-6 text-center">
-          <p className="font-black uppercase tracking-widest text-sm text-gray-500">
-            No upcoming Codeforces contests scheduled for this division.
-          </p>
-        </div>
-      ) : (
-
-        <div className={compact ? "flex flex-col gap-3" : "grid grid-cols-1 lg:grid-cols-2 gap-6"}>
-          {visibleContests.map((contest) => (
+      <div
+        className={
+          compact
+            ? "grid grid-cols-1 sm:grid-cols-3 gap-4"
+            : "grid grid-cols-1 lg:grid-cols-2 gap-6"
+        }
+      >
+        {visibleContests.map((contest) => (
+          <div
+            key={contest.contestId}
+            className={`flex flex-col border-4 border-black bg-white ${
+              compact ? "p-4" : "p-6"
+            } hover:shadow-[8px_8px_0_0_rgba(0,0,0,1)] transition-all`}
+          >
             <div
-              key={contest.contestId}
-              className={`border-4 border-black bg-white ${compact ? "p-4" : "p-6"
-                } hover:shadow-[8px_8px_0_0_rgba(0,0,0,1)] transition-all`}
+              className={`flex items-start justify-between gap-2 ${
+                compact ? "mb-2" : "mb-3"
+              }`}
             >
-              <div className="flex items-start justify-between gap-3 mb-3">
-                <div className="border-2 border-blue-600 bg-blue-50 text-blue-800 px-3 py-1 text-xs font-black uppercase tracking-wide shrink-0">
-                  {contest.division}
-                </div>
-                <ContestCountdown
-                  msUntilStart={contest.msUntilStart}
-                  isRunning={contest.isRunning}
-                />
-              </div>
-
-              <h3
-                className={`font-black uppercase tracking-tight text-black mb-3 ${compact ? "text-base" : "text-xl"
-                  }`}
+              <div
+                className={`border-2 border-blue-600 bg-blue-50 text-blue-800 font-black uppercase tracking-wide shrink-0 ${
+                  compact ? "px-2 py-0.5 text-[10px]" : "px-3 py-1 text-xs"
+                }`}
               >
-                {contest.name}
-              </h3>
-
-              <div className="flex flex-wrap justify-between items-center gap-2 text-xs font-bold uppercase tracking-wide text-gray-600 mb-4">
-                <span>{formatStartTime(contest.startTimeSeconds)}</span>
-                <span>{formatDuration(contest.durationSeconds)}</span>
+                {contest.division}
               </div>
+              <ContestCountdown
+                msUntilStart={contest.msUntilStart}
+                isRunning={contest.isRunning}
+                compact={compact}
+              />
+            </div>
 
-              <button
-                onClick={() => handleReminderClick(contest.contestId)}
-                className={`w-full px-4 py-3 border-4 border-black font-black uppercase tracking-widest text-sm transition-colors ${contest.hasReminder
+            <h3
+              className={`font-black uppercase tracking-tight text-black ${
+                compact ? "text-sm mb-2 line-clamp-2 min-h-[2.5em]" : "text-xl mb-3"
+              }`}
+            >
+              {contest.name}
+            </h3>
+
+            <div
+              className={
+                compact
+                  ? "flex flex-col gap-1 font-bold uppercase tracking-wide text-gray-600 text-[10px] mb-3"
+                  : "flex flex-row flex-wrap justify-between items-center gap-2 font-bold uppercase tracking-wide text-gray-600 text-xs mb-4"
+              }
+            >
+              <span className="flex items-center gap-1">
+                <Calendar size={compact ? 11 : 13} strokeWidth={2.5} />
+                {formatStartTime(contest.startTimeSeconds)}
+              </span>
+              <span className="flex items-center gap-1">
+                <Timer size={compact ? 11 : 13} strokeWidth={2.5} />
+                {formatDuration(contest.durationSeconds)}
+              </span>
+            </div>
+
+            <button
+              onClick={() => handleReminderClick(contest.contestId)}
+              className={`mt-auto w-full flex items-center justify-center gap-2 border-4 border-black font-black uppercase tracking-widest transition-colors ${
+                compact ? "px-3 py-2 text-xs" : "px-4 py-3 text-sm"
+              } ${
+                contest.hasReminder
                   ? "bg-black text-white hover:bg-gray-800"
                   : "bg-white text-black hover:bg-blue-600 hover:text-white hover:border-blue-600"
-                  }`}
-              >
-                {contest.hasReminder ? "🔔 Reminder Set" : "🔕 Remind Me"}
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
+              }`}
+            >
+              {contest.hasReminder ? (
+                <>
+                  <Bell size={compact ? 14 : 16} strokeWidth={2.5} />
+                  {compact ? "Set" : "Reminder Set"}
+                </>
+              ) : (
+                <>
+                  <BellOff size={compact ? 14 : 16} strokeWidth={2.5} />
+                  Remind Me
+                </>
+              )}
+            </button>
+          </div>
+        ))}
+      </div>
 
       {compact && (
         <Link

--- a/frontend/src/components/contests/UpcomingContestsList.jsx
+++ b/frontend/src/components/contests/UpcomingContestsList.jsx
@@ -1,0 +1,154 @@
+import { useState, useMemo } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext";
+import { useContests } from "../../hooks/useContests";
+import ContestCountdown from "./ContestCountdown";
+
+const DIVISIONS = ["all", "Div. 1", "Div. 2", "Div. 3", "Div. 4", "Educational", "Global"];
+
+function formatStartTime(startTimeSeconds) {
+  return new Date(startTimeSeconds * 1000).toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatDuration(durationSeconds) {
+  const hours = Math.floor(durationSeconds / 3600);
+  const minutes = Math.round((durationSeconds % 3600) / 60);
+  return minutes ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
+export default function UpcomingContestsList({ compact = false, limit = 3 }) {
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+  const { contests, loading, error, toggleReminder } = useContests();
+  const [division, setDivision] = useState("all");
+  const [reminderError, setReminderError] = useState(null);
+
+  const visibleContests = useMemo(() => {
+    const filtered =
+      division === "all" ? contests : contests.filter((c) => c.division === division);
+    return compact ? filtered.slice(0, limit) : filtered;
+  }, [contests, division, compact, limit]);
+
+  const handleReminderClick = async (contestId) => {
+    if (!isAuthenticated) {
+      navigate("/login");
+      return;
+    }
+    setReminderError(null);
+    try {
+      await toggleReminder(contestId);
+    } catch {
+      setReminderError("Couldn't update reminder. Please try again.");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="w-10 h-10 border-[4px] border-black border-t-transparent animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="border-4 border-black bg-white p-6 text-center">
+        <p className="font-black uppercase tracking-widest text-sm text-red-600">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {!compact && (
+        <div className="flex flex-wrap gap-3 mb-8">
+          {DIVISIONS.map((div) => (
+            <button
+              key={div}
+              onClick={() => setDivision(div)}
+              className={`px-6 py-3 border-4 border-black font-black text-sm uppercase tracking-widest transition-all ${
+                division === div
+                  ? "bg-blue-600 text-white"
+                  : "bg-white text-black hover:bg-blue-600 hover:text-white"
+              }`}
+            >
+              {div}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {reminderError && (
+        <p className="font-black uppercase tracking-widest text-xs text-red-600 mb-4">
+          {reminderError}
+        </p>
+      )}
+
+      {visibleContests.length === 0 ? (
+        <div className="border-4 border-black bg-white p-6 text-center">
+          <p className="font-black uppercase tracking-widest text-sm text-gray-500">
+            No upcoming Codeforces contests scheduled for this division.
+          </p>
+        </div>
+      ) : (
+
+        <div className={compact ? "flex flex-col gap-3" : "grid grid-cols-1 lg:grid-cols-2 gap-6"}>
+          {visibleContests.map((contest) => (
+            <div
+              key={contest.contestId}
+              className={`border-4 border-black bg-white ${compact ? "p-4" : "p-6"
+                } hover:shadow-[8px_8px_0_0_rgba(0,0,0,1)] transition-all`}
+            >
+              <div className="flex items-start justify-between gap-3 mb-3">
+                <div className="border-2 border-blue-600 bg-blue-50 text-blue-800 px-3 py-1 text-xs font-black uppercase tracking-wide shrink-0">
+                  {contest.division}
+                </div>
+                <ContestCountdown
+                  msUntilStart={contest.msUntilStart}
+                  isRunning={contest.isRunning}
+                />
+              </div>
+
+              <h3
+                className={`font-black uppercase tracking-tight text-black mb-3 ${compact ? "text-base" : "text-xl"
+                  }`}
+              >
+                {contest.name}
+              </h3>
+
+              <div className="flex flex-wrap justify-between items-center gap-2 text-xs font-bold uppercase tracking-wide text-gray-600 mb-4">
+                <span>{formatStartTime(contest.startTimeSeconds)}</span>
+                <span>{formatDuration(contest.durationSeconds)}</span>
+              </div>
+
+              <button
+                onClick={() => handleReminderClick(contest.contestId)}
+                className={`w-full px-4 py-3 border-4 border-black font-black uppercase tracking-widest text-sm transition-colors ${contest.hasReminder
+                  ? "bg-black text-white hover:bg-gray-800"
+                  : "bg-white text-black hover:bg-blue-600 hover:text-white hover:border-blue-600"
+                  }`}
+              >
+                {contest.hasReminder ? "🔔 Reminder Set" : "🔕 Remind Me"}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {compact && (
+        <Link
+          to="/contests/codeforces"
+          className="block mt-4 text-center text-xs font-black uppercase tracking-widest text-blue-600 hover:text-black transition-colors"
+        >
+          View All Upcoming Contests →
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/UpcomingContestsWidget.jsx
+++ b/frontend/src/components/dashboard/UpcomingContestsWidget.jsx
@@ -1,11 +1,19 @@
+import { CalendarClock } from "lucide-react";
 import UpcomingContestsList from "../contests/UpcomingContestsList";
 
+/**
+ * Dashboard-sized preview of the Codeforces contest tracker — top 3 upcoming
+ * contests with a link through to the full /contests/codeforces page.
+ */
 export default function UpcomingContestsWidget() {
   return (
-    <div className="border-4 border-black p-6 sm:p-8 bg-white shadow-[8px_8px_0_0_rgba(0,0,0,1)]">
-      <h3 className="text-2xl sm:text-3xl font-black uppercase tracking-tighter text-black mb-6 border-b-4 border-black pb-4">
-        Upcoming Contests
-      </h3>
+    <div className="w-full border-4 border-black p-6 sm:p-8 bg-white shadow-[8px_8px_0_0_rgba(0,0,0,1)]">
+      <div className="flex items-center gap-3 mb-6 border-b-4 border-black pb-4">
+        <CalendarClock size={26} strokeWidth={2.5} className="text-black shrink-0" />
+        <h3 className="text-xl sm:text-2xl font-black uppercase tracking-tighter text-black">
+          Upcoming Contests
+        </h3>
+      </div>
       <UpcomingContestsList compact limit={3} />
     </div>
   );

--- a/frontend/src/components/dashboard/UpcomingContestsWidget.jsx
+++ b/frontend/src/components/dashboard/UpcomingContestsWidget.jsx
@@ -1,0 +1,12 @@
+import UpcomingContestsList from "../contests/UpcomingContestsList";
+
+export default function UpcomingContestsWidget() {
+  return (
+    <div className="border-4 border-black p-6 sm:p-8 bg-white shadow-[8px_8px_0_0_rgba(0,0,0,1)]">
+      <h3 className="text-2xl sm:text-3xl font-black uppercase tracking-tighter text-black mb-6 border-b-4 border-black pb-4">
+        Upcoming Contests
+      </h3>
+      <UpcomingContestsList compact limit={3} />
+    </div>
+  );
+}

--- a/frontend/src/components/shared/ContestReminderNotifier.jsx
+++ b/frontend/src/components/shared/ContestReminderNotifier.jsx
@@ -1,10 +1,18 @@
 import { useState, useEffect, useRef } from "react";
+import { Bell, X } from "lucide-react";
 import { useAuth } from "../../context/AuthContext";
 import { getMyActiveReminders, markReminderNotified } from "../../services/contestService";
 
-const POLL_INTERVAL_MS = 30_000;
-const REMINDER_WINDOW_MS = 15 * 60 * 1000;
+const POLL_INTERVAL_MS = 30_000; // 30s — frequent enough to catch the reminder window
+const REMINDER_WINDOW_MS = 15 * 60 * 1000; // toast fires when a contest starts within 15 minutes
 
+/**
+ * Mounted once in MainLayout. While the user is active on the platform and
+ * signed in, polls their contest reminders and pops an in-app toast when a
+ * reminder-contest is starting within REMINDER_WINDOW_MS. Each reminder only
+ * ever toasts once — the backend persists `notifiedAt` so this survives
+ * page reloads/navigation.
+ */
 export default function ContestReminderNotifier() {
   const { isAuthenticated } = useAuth();
   const [toast, setToast] = useState(null);
@@ -38,7 +46,7 @@ export default function ContestReminderNotifier() {
           markReminderNotified(due.contestId).catch(() => {});
         }
       } catch {
-        // Silent
+        // Silent — non-critical background polling.
       }
     };
 
@@ -58,8 +66,9 @@ export default function ContestReminderNotifier() {
     <div className="fixed bottom-6 right-6 z-[100] max-w-sm border-4 border-black bg-black text-white p-5 shadow-[8px_8px_0_0_rgba(0,0,0,0.4)]">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <p className="text-xs font-black uppercase tracking-widest text-blue-400 mb-1">
-            🔔 Contest Starting Soon
+          <p className="flex items-center gap-1.5 text-xs font-black uppercase tracking-widest text-blue-400 mb-1">
+            <Bell size={13} strokeWidth={2.5} />
+            Contest Starting Soon
           </p>
           <p className="font-black uppercase tracking-tight text-sm mb-1">{toast.name}</p>
           <p className="text-xs font-bold text-gray-300">
@@ -69,9 +78,9 @@ export default function ContestReminderNotifier() {
         <button
           onClick={() => setToast(null)}
           aria-label="Dismiss"
-          className="text-gray-400 hover:text-white font-black text-lg leading-none"
+          className="text-gray-400 hover:text-white transition-colors"
         >
-          ×
+          <X size={18} strokeWidth={2.5} />
         </button>
       </div>
     </div>

--- a/frontend/src/components/shared/ContestReminderNotifier.jsx
+++ b/frontend/src/components/shared/ContestReminderNotifier.jsx
@@ -1,0 +1,79 @@
+import { useState, useEffect, useRef } from "react";
+import { useAuth } from "../../context/AuthContext";
+import { getMyActiveReminders, markReminderNotified } from "../../services/contestService";
+
+const POLL_INTERVAL_MS = 30_000;
+const REMINDER_WINDOW_MS = 15 * 60 * 1000;
+
+export default function ContestReminderNotifier() {
+  const { isAuthenticated } = useAuth();
+  const [toast, setToast] = useState(null);
+  const shownThisSession = useRef(new Set());
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const { data } = await getMyActiveReminders();
+        if (cancelled) return;
+
+        const now = Date.now();
+        const due = (data.data || []).find((c) => {
+          if (c.notifiedAt) return false;
+          if (shownThisSession.current.has(c.contestId)) return false;
+          const msUntilStart = c.startTimeSeconds * 1000 - now;
+          return msUntilStart > 0 && msUntilStart <= REMINDER_WINDOW_MS;
+        });
+
+        if (due) {
+          shownThisSession.current.add(due.contestId);
+          const minutesLeft = Math.max(
+            1,
+            Math.round((due.startTimeSeconds * 1000 - now) / 60000)
+          );
+          setToast({ ...due, minutesLeft });
+          markReminderNotified(due.contestId).catch(() => {});
+        }
+      } catch {
+        // Silent
+      }
+    };
+
+    poll();
+    const id = setInterval(poll, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [isAuthenticated]);
+
+  if (!toast) return null;
+
+  const { minutesLeft } = toast;
+
+  return (
+    <div className="fixed bottom-6 right-6 z-[100] max-w-sm border-4 border-black bg-black text-white p-5 shadow-[8px_8px_0_0_rgba(0,0,0,0.4)]">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-black uppercase tracking-widest text-blue-400 mb-1">
+            🔔 Contest Starting Soon
+          </p>
+          <p className="font-black uppercase tracking-tight text-sm mb-1">{toast.name}</p>
+          <p className="text-xs font-bold text-gray-300">
+            Starts in ~{minutesLeft} minute{minutesLeft === 1 ? "" : "s"}
+          </p>
+        </div>
+        <button
+          onClick={() => setToast(null)}
+          aria-label="Dismiss"
+          className="text-gray-400 hover:text-white font-black text-lg leading-none"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shared/Navbar.jsx
+++ b/frontend/src/components/shared/Navbar.jsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
+import ContestReminderBell from "../contests/ContestReminderBell";
 
 // ─── Mega Menu Data  ───────────────────────────────────────────────
 const MEGA_MENU_ITEMS = [
@@ -512,6 +513,10 @@ export default function Navbar() {
             </>
           ) : (
             <>
+
+              {/* Contest reminder bell — badge shows reminders due in <24h */}
+              <ContestReminderBell />
+              
               {/* User identity chip */}
               <div className="flex items-center gap-2 pl-3 border-l border-zinc-200">
                 <span className="w-7 h-7 flex items-center justify-center bg-black text-white font-bold text-xs rounded-[2px] flex-shrink-0">

--- a/frontend/src/hooks/useContests.js
+++ b/frontend/src/hooks/useContests.js
@@ -1,0 +1,98 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useAuth } from "../context/AuthContext";
+import {
+  getUpcomingCodeforcesContests,
+  getMyReminderIds,
+  addContestReminder,
+  removeContestReminder,
+} from "../services/contestService";
+
+export const useContests = () => {
+  const { isAuthenticated } = useAuth();
+
+  const [contests, setContests] = useState([]);
+  const [reminderIds, setReminderIds] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [now, setNow] = useState(Date.now());
+
+  const fetchContests = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await getUpcomingCodeforcesContests();
+      setContests(data.data || []);
+    } catch (err) {
+      setError(err.response?.data?.message || "Failed to load upcoming contests.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchReminders = useCallback(async () => {
+    if (!isAuthenticated) {
+      setReminderIds([]);
+      return;
+    }
+    try {
+      const { data } = await getMyReminderIds();
+      setReminderIds(data.data || []);
+    } catch {
+      // Non-fatal
+    }
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    fetchContests();
+  }, [fetchContests]);
+
+  useEffect(() => {
+    fetchReminders();
+  }, [fetchReminders]);
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const toggleReminder = async (contestId) => {
+    const hasReminder = reminderIds.includes(contestId);
+    setReminderIds((prev) =>
+      hasReminder ? prev.filter((id) => id !== contestId) : [...prev, contestId]
+    );
+    try {
+      if (hasReminder) {
+        await removeContestReminder(contestId);
+      } else {
+        await addContestReminder(contestId);
+      }
+    } catch (err) {
+      setReminderIds((prev) =>
+        hasReminder ? [...prev, contestId] : prev.filter((id) => id !== contestId)
+      );
+      throw err;
+    }
+  };
+
+  const contestsWithMeta = useMemo(() => {
+    return contests.map((contest) => {
+      const startMs = contest.startTimeSeconds * 1000;
+      const endMs = startMs + contest.durationSeconds * 1000;
+      return {
+        ...contest,
+        hasReminder: reminderIds.includes(contest.contestId),
+        isRunning: now >= startMs && now < endMs,
+        msUntilStart: startMs - now,
+      };
+    });
+  }, [contests, reminderIds, now]);
+
+  return {
+    contests: contestsWithMeta,
+    loading,
+    error,
+    now,
+    toggleReminder,
+    refetch: fetchContests,
+  };
+};

--- a/frontend/src/layouts/MainLayout.jsx
+++ b/frontend/src/layouts/MainLayout.jsx
@@ -1,5 +1,6 @@
 import Navbar from "../components/shared/Navbar";
 import Footer from "../components/shared/Footer";
+import ContestReminderNotifier from "../components/shared/ContestReminderNotifier";
 
 export default function MainLayout({ children }) {
   return (
@@ -9,6 +10,7 @@ export default function MainLayout({ children }) {
         {children}
       </main>
       <Footer />
+      <ContestReminderNotifier />
     </div>
   );
 }

--- a/frontend/src/pages/ContestCodeforcesPage.jsx
+++ b/frontend/src/pages/ContestCodeforcesPage.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import UpcomingContestsList from "../components/contests/UpcomingContestsList";
 
 export default function ContestCodeforcesPage() {
   const [selectedDivision, setSelectedDivision] = useState("all");
@@ -75,24 +76,13 @@ export default function ContestCodeforcesPage() {
         </div>
       </section>
 
-      {/* Filter Section */}
-      <section className="w-full border-b-4 border-black px-4 sm:px-6 md:px-8 py-8 bg-gray-50">
+      {/* Upcoming Contests Tracker — live data from Codeforces, cached hourly */}
+      <section className="w-full border-b-4 border-black px-4 sm:px-6 md:px-8 py-12 sm:py-16">
         <div className="max-w-7xl mx-auto">
-          <div className="flex flex-wrap gap-3">
-            {["all", "Div. 1", "Div. 2", "Div. 3", "Div. 4", "Educational", "Global"].map((div) => (
-              <button
-                key={div}
-                onClick={() => setSelectedDivision(div)}
-                className={`px-6 py-3 border-4 border-black font-black text-sm uppercase tracking-widest transition-all ${
-                  selectedDivision === div
-                    ? "bg-blue-600 text-white"
-                    : "bg-white text-black hover:bg-blue-600 hover:text-white"
-                }`}
-              >
-                {div}
-              </button>
-            ))}
-          </div>
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-black uppercase tracking-tighter text-black mb-8 sm:mb-12">
+            Upcoming Contests
+          </h2>
+          <UpcomingContestsList />
         </div>
       </section>
 

--- a/frontend/src/pages/ContestCodeforcesPage.jsx
+++ b/frontend/src/pages/ContestCodeforcesPage.jsx
@@ -1,9 +1,7 @@
-import { useState } from "react";
+import { Trophy, CheckCircle2, Zap, BarChart3 } from "lucide-react";
 import UpcomingContestsList from "../components/contests/UpcomingContestsList";
 
 export default function ContestCodeforcesPage() {
-  const [selectedDivision, setSelectedDivision] = useState("all");
-
   const contestSolutions = [
     {
       id: 1,
@@ -37,11 +35,11 @@ export default function ContestCodeforcesPage() {
   return (
     <div className="w-full min-h-screen bg-white">
       {/* Hero Section */}
-      <section className="w-full border-b-4 border-black px-4 sm:px-6 md:px-8 py-16 sm:py-20 md:py-24 bg-gradient-to-br from-blue-50 to-white">
+      <section className="w-full border-b-4 border-black px-4 sm:px-6 md:px-8 py-16 sm:py-20 md:py-24 bg-white">
         <div className="max-w-7xl mx-auto">
           <div className="text-center space-y-6 sm:space-y-8">
             <div className="inline-flex items-center gap-3 border-4 border-black bg-blue-600 text-white px-6 py-3">
-              <span className="text-2xl">🔵</span>
+              <Trophy size={22} strokeWidth={2.5} />
               <span className="font-black text-sm sm:text-base uppercase tracking-widest">
                 Contest Arsenal
               </span>
@@ -86,7 +84,7 @@ export default function ContestCodeforcesPage() {
         </div>
       </section>
 
-      {/* Contest Solutions Grid */}
+      {/* Contest Solutions Grid (past-contest editorial archive — static placeholder) */}
       <section className="w-full px-4 sm:px-6 md:px-8 py-12 sm:py-16 md:py-20">
         <div className="max-w-7xl mx-auto">
           <h2 className="text-3xl sm:text-4xl md:text-5xl font-black uppercase tracking-tighter text-black mb-8 sm:mb-12">
@@ -158,21 +156,21 @@ export default function ContestCodeforcesPage() {
         <div className="max-w-7xl mx-auto">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div className="border-4 border-black bg-white p-6">
-              <div className="text-4xl font-black mb-4">✓</div>
+              <CheckCircle2 size={36} strokeWidth={2.5} className="mb-4 text-black" />
               <h3 className="text-xl font-black uppercase tracking-tight mb-3">Detailed Editorials</h3>
               <p className="text-sm font-bold leading-relaxed text-gray-700">
                 Step-by-step explanations with multiple approaches and optimizations
               </p>
             </div>
             <div className="border-4 border-black bg-white p-6">
-              <div className="text-4xl font-black mb-4">⚡</div>
+              <Zap size={36} strokeWidth={2.5} className="mb-4 text-black" />
               <h3 className="text-xl font-black uppercase tracking-tight mb-3">Code Templates</h3>
               <p className="text-sm font-bold leading-relaxed text-gray-700">
                 Clean, production-ready code in C++, Python, and Java
               </p>
             </div>
             <div className="border-4 border-black bg-white p-6">
-              <div className="text-4xl font-black mb-4">📊</div>
+              <BarChart3 size={36} strokeWidth={2.5} className="mb-4 text-black" />
               <h3 className="text-xl font-black uppercase tracking-tight mb-3">Complexity Analysis</h3>
               <p className="text-sm font-bold leading-relaxed text-gray-700">
                 Time and space complexity breakdown for every solution

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -5,6 +5,7 @@ import { useCodeforces } from "../hooks/useCodeforces";
 import ConnectBanner from "../components/codeforces/ConnectBanner";
 import VerifyModal from "../components/codeforces/VerifyModal";
 import DashboardExecutiveSummary from "../components/dashboard/DashboardExecutiveSummary";
+import UpcomingContestsWidget from "../components/dashboard/UpcomingContestsWidget";
 import LoaderSwitcher from "../components/shared/loaders/LoaderSwitcher";
 
 export default function DashboardPage() {
@@ -131,6 +132,11 @@ export default function DashboardPage() {
               </div>
             </div>
           </div>
+        </div>
+
+        {/* Upcoming Contests Widget */}
+        <div className="mb-12 sm:mb-16">
+          <UpcomingContestsWidget />
         </div>
 
         {/* Connect Banner — only shown if CF is not connected */}

--- a/frontend/src/services/contestService.js
+++ b/frontend/src/services/contestService.js
@@ -1,0 +1,17 @@
+import api from "./api.js";
+
+export const getUpcomingCodeforcesContests = () =>
+  api.get("/contests/codeforces/upcoming");
+
+export const getMyReminderIds = () => api.get("/contests/reminders");
+
+export const getMyActiveReminders = () => api.get("/contests/reminders/active");
+
+export const addContestReminder = (contestId) =>
+  api.post("/contests/reminders", { contestId });
+
+export const removeContestReminder = (contestId) =>
+  api.delete(`/contests/reminders/${contestId}`);
+
+export const markReminderNotified = (contestId) =>
+  api.post(`/contests/reminders/${contestId}/notified`);

--- a/server/app.js
+++ b/server/app.js
@@ -7,6 +7,7 @@ import userRoutes from "./modules/user/routes.js";
 import codeforcesRoutes from "./modules/codeforces/routes.js";
 import aiRoutes from "./modules/ai/routes.js";
 import githubRoutes from "./modules/github/routes.js";
+import contestRoutes from "./modules/contests/routes.js";
 import { globalLimiter, apiLimiter } from "./middlewares/rateLimiter.js";
 
 const app = express();
@@ -61,6 +62,7 @@ app.use("/api/user",       userRoutes);
 app.use("/api/codeforces", codeforcesRoutes);
 app.use("/api/ai",         aiRoutes);
 app.use("/api/github",     githubRoutes);
+app.use("/api/contests",   contestRoutes);
 
 // ── 404 catch-all ─────────────────────────────────────────────────────────────
 app.use((req, res) => {

--- a/server/jobs/contestSync.js
+++ b/server/jobs/contestSync.js
@@ -1,0 +1,16 @@
+import cron from "node-cron";
+import ContestService from "../modules/contests/service.js";
+
+export const startContestSyncJob = () => {
+  const runSync = async () => {
+    try {
+      const { synced } = await ContestService.syncCodeforcesContests();
+      console.log(`[Contest Sync] Synced ${synced} Codeforces contest(s).`);
+    } catch (err) {
+      console.error("[Contest Sync Error]", err.message);
+    }
+  };
+
+  runSync();
+  cron.schedule("0 * * * *", runSync);
+};

--- a/server/models/Contest.js
+++ b/server/models/Contest.js
@@ -1,0 +1,32 @@
+import mongoose from "mongoose";
+
+/**
+ * Caches the Codeforces `contest.list` API response so the frontend never
+ * has to hit Codeforces directly (avoids rate-limiting, keeps load times fast).
+ * Refreshed hourly by `server/jobs/contestSync.js`.
+ */
+const ContestSchema = new mongoose.Schema(
+  {
+    platform: {
+      type: String,
+      enum: ["codeforces"],
+      default: "codeforces",
+      required: true,
+      index: true,
+    },
+    contestId: { type: Number, required: true, index: true },
+    name: { type: String, required: true },
+    type: { type: String, default: "CF" },
+    phase: { type: String, required: true, index: true },
+    division: { type: String, default: "Other" },
+    durationSeconds: { type: Number, required: true },
+    startTimeSeconds: { type: Number, required: true, index: true },
+    relativeTimeSeconds: { type: Number },
+    lastSyncedAt: { type: Date, default: Date.now },
+  },
+  { timestamps: true }
+);
+
+ContestSchema.index({ platform: 1, contestId: 1 }, { unique: true });
+
+export default mongoose.model("Contest", ContestSchema);

--- a/server/models/ContestReminder.js
+++ b/server/models/ContestReminder.js
@@ -1,0 +1,32 @@
+import mongoose from "mongoose";
+
+/**
+ * A user's opt-in to be reminded about a specific upcoming contest.
+ * One document per (user, contest) pair.
+ */
+const ContestReminderSchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      index: true,
+    },
+    platform: {
+      type: String,
+      enum: ["codeforces"],
+      default: "codeforces",
+      required: true,
+    },
+    contestId: { type: Number, required: true },
+    notifiedAt: { type: Date, default: null },
+  },
+  { timestamps: true }
+);
+
+ContestReminderSchema.index(
+  { user: 1, platform: 1, contestId: 1 },
+  { unique: true }
+);
+
+export default mongoose.model("ContestReminder", ContestReminderSchema);

--- a/server/modules/contests/controller.js
+++ b/server/modules/contests/controller.js
@@ -1,0 +1,71 @@
+import ApiResponse from "../../utils/ApiResponse.js";
+import ApiError from "../../utils/ApiError.js";
+import ContestService from "./service.js";
+
+class ContestController {
+  static async getUpcomingCodeforcesContests(req, res, next) {
+    try {
+      const contests = await ContestService.getUpcomingContests();
+      res
+        .status(200)
+        .json(ApiResponse.success("Upcoming Codeforces contests fetched.", contests));
+    } catch (err) {
+      next(err instanceof ApiError ? err : new ApiError(500, err.message));
+    }
+  }
+
+  static async getReminderIds(req, res, next) {
+    try {
+      const contestIds = await ContestService.getUserReminderIds(req.user._id);
+      res.status(200).json(ApiResponse.success("Reminders fetched.", contestIds));
+    } catch (err) {
+      next(err instanceof ApiError ? err : new ApiError(500, err.message));
+    }
+  }
+
+  static async getActiveReminders(req, res, next) {
+    try {
+      const reminders = await ContestService.getActiveReminders(req.user._id);
+      res.status(200).json(ApiResponse.success("Active reminders fetched.", reminders));
+    } catch (err) {
+      next(err instanceof ApiError ? err : new ApiError(500, err.message));
+    }
+  }
+
+  static async addReminder(req, res, next) {
+    try {
+      const result = await ContestService.addReminder(req.user._id, req.body.contestId);
+      res.status(200).json(ApiResponse.success(result.message, result));
+    } catch (err) {
+      next(err instanceof ApiError ? err : new ApiError(500, err.message));
+    }
+  }
+
+  static async removeReminder(req, res, next) {
+    try {
+      const contestId = parseInt(req.params.contestId, 10);
+      if (Number.isNaN(contestId)) {
+        throw new ApiError(400, "Invalid contest id.");
+      }
+      const result = await ContestService.removeReminder(req.user._id, contestId);
+      res.status(200).json(ApiResponse.success(result.message, result));
+    } catch (err) {
+      next(err instanceof ApiError ? err : new ApiError(500, err.message));
+    }
+  }
+
+  static async markNotified(req, res, next) {
+    try {
+      const contestId = parseInt(req.params.contestId, 10);
+      if (Number.isNaN(contestId)) {
+        throw new ApiError(400, "Invalid contest id.");
+      }
+      const result = await ContestService.markReminderNotified(req.user._id, contestId);
+      res.status(200).json(ApiResponse.success(result.message, result));
+    } catch (err) {
+      next(err instanceof ApiError ? err : new ApiError(500, err.message));
+    }
+  }
+}
+
+export default ContestController;

--- a/server/modules/contests/repository.js
+++ b/server/modules/contests/repository.js
@@ -1,0 +1,96 @@
+import Contest from "../../models/Contest.js";
+import ContestReminder from "../../models/ContestReminder.js";
+
+class ContestRepository {
+  static async bulkUpsertContests(contests) {
+    if (!contests.length) return;
+
+    const ops = contests.map((c) => ({
+      updateOne: {
+        filter: { platform: c.platform, contestId: c.contestId },
+        update: { $set: c },
+        upsert: true,
+      },
+    }));
+
+    return Contest.bulkWrite(ops, { ordered: false });
+  }
+
+  static async getUpcomingContests(platform = "codeforces") {
+    return Contest.find({
+      platform,
+      phase: { $in: ["BEFORE", "CODING"] },
+    })
+      .sort({ startTimeSeconds: 1 })
+      .lean();
+  }
+
+  static async findByContestId(platform, contestId) {
+    return Contest.findOne({ platform, contestId }).lean();
+  }
+
+  static async addReminder(userId, platform, contestId) {
+    return ContestReminder.findOneAndUpdate(
+      { user: userId, platform, contestId },
+      { $setOnInsert: { user: userId, platform, contestId } },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+  }
+
+  static async removeReminder(userId, platform, contestId) {
+    return ContestReminder.findOneAndDelete({ user: userId, platform, contestId });
+  }
+
+  static async getReminderContestIds(userId, platform = "codeforces") {
+    const reminders = await ContestReminder.find({ user: userId, platform })
+      .select("contestId -_id")
+      .lean();
+    return reminders.map((r) => r.contestId);
+  }
+
+  static async getActiveReminderContests(userId, platform = "codeforces") {
+    const reminders = await ContestReminder.find({ user: userId, platform }).lean();
+    if (!reminders.length) return [];
+
+    const contestIds = reminders.map((r) => r.contestId);
+    const contests = await Contest.find({
+      platform,
+      contestId: { $in: contestIds },
+      phase: { $in: ["BEFORE", "CODING"] },
+    }).lean();
+
+    const reminderByContestId = new Map(reminders.map((r) => [r.contestId, r]));
+
+    return contests
+      .map((contest) => ({
+        ...contest,
+        notifiedAt: reminderByContestId.get(contest.contestId)?.notifiedAt ?? null,
+      }))
+      .sort((a, b) => a.startTimeSeconds - b.startTimeSeconds);
+  }
+
+  static async markNotified(userId, platform, contestId) {
+    return ContestReminder.findOneAndUpdate(
+      { user: userId, platform, contestId },
+      { $set: { notifiedAt: new Date() } }
+    );
+  }
+
+  static async pruneStaleReminders(platform = "codeforces") {
+    const finishedContestIds = await Contest.find({
+      platform,
+      phase: "FINISHED",
+    })
+      .select("contestId -_id")
+      .lean();
+
+    if (!finishedContestIds.length) return;
+
+    await ContestReminder.deleteMany({
+      platform,
+      contestId: { $in: finishedContestIds.map((c) => c.contestId) },
+    });
+  }
+}
+
+export default ContestRepository;

--- a/server/modules/contests/routes.js
+++ b/server/modules/contests/routes.js
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import authMiddleware from "../../middlewares/authMiddleware.js";
+import ContestController from "./controller.js";
+import { validate, addReminderSchema } from "./validation.js";
+
+const router = Router();
+
+router.get("/codeforces/upcoming", ContestController.getUpcomingCodeforcesContests);
+
+router.use(authMiddleware);
+
+router.get("/reminders", ContestController.getReminderIds);
+router.get("/reminders/active", ContestController.getActiveReminders);
+router.post("/reminders", validate(addReminderSchema), ContestController.addReminder);
+router.delete("/reminders/:contestId", ContestController.removeReminder);
+router.post("/reminders/:contestId/notified", ContestController.markNotified);
+
+export default router;

--- a/server/modules/contests/service.js
+++ b/server/modules/contests/service.js
@@ -1,0 +1,91 @@
+import ApiError from "../../utils/ApiError.js";
+import ContestRepository from "./repository.js";
+import { cfGetContestList } from "../../utils/codeforcesApi.js";
+
+const parseDivision = (name = "") => {
+  const n = name.toLowerCase();
+  if (n.includes("div. 1") && n.includes("div. 2")) return "Div. 1 + 2";
+  if (n.includes("div. 1")) return "Div. 1";
+  if (n.includes("div. 2")) return "Div. 2";
+  if (n.includes("div. 3")) return "Div. 3";
+  if (n.includes("div. 4")) return "Div. 4";
+  if (n.includes("educational")) return "Educational";
+  if (n.includes("global")) return "Global";
+  if (n.includes("kotlin")) return "Kotlin Heroes";
+  if (n.includes("icpc")) return "ICPC";
+  return "Other";
+};
+
+const normalizeContest = (c) => ({
+  platform: "codeforces",
+  contestId: c.id,
+  name: c.name,
+  type: c.type,
+  phase: c.phase,
+  division: parseDivision(c.name),
+  durationSeconds: c.durationSeconds,
+  startTimeSeconds: c.startTimeSeconds,
+  relativeTimeSeconds: c.relativeTimeSeconds,
+  lastSyncedAt: new Date(),
+});
+
+class ContestService {
+  static async syncCodeforcesContests() {
+    const contests = await cfGetContestList(false);
+
+    const relevant = contests.filter((c) =>
+      ["BEFORE", "CODING", "FINISHED"].includes(c.phase)
+    );
+
+    const finished = relevant
+      .filter((c) => c.phase === "FINISHED")
+      .sort((a, b) => b.startTimeSeconds - a.startTimeSeconds)
+      .slice(0, 20);
+
+    const upcomingOrRunning = relevant.filter((c) => c.phase !== "FINISHED");
+
+    const docs = [...upcomingOrRunning, ...finished].map(normalizeContest);
+
+    await ContestRepository.bulkUpsertContests(docs);
+    await ContestRepository.pruneStaleReminders("codeforces");
+
+    return { synced: docs.length };
+  }
+
+  static async getUpcomingContests() {
+    return ContestRepository.getUpcomingContests("codeforces");
+  }
+
+  static async getUserReminderIds(userId) {
+    return ContestRepository.getReminderContestIds(userId, "codeforces");
+  }
+
+  static async addReminder(userId, contestId) {
+    const contest = await ContestRepository.findByContestId("codeforces", contestId);
+    if (!contest) {
+      throw new ApiError(404, "Contest not found. It may have already started or ended.");
+    }
+    if (!["BEFORE", "CODING"].includes(contest.phase)) {
+      throw new ApiError(400, "Reminders can only be set for upcoming or running contests.");
+    }
+
+    await ContestRepository.addReminder(userId, "codeforces", contestId);
+    return { message: `Reminder set for "${contest.name}".`, contestId };
+  }
+
+  static async removeReminder(userId, contestId) {
+    await ContestRepository.removeReminder(userId, "codeforces", contestId);
+    return { message: "Reminder removed.", contestId };
+  }
+
+  static async getActiveReminders(userId) {
+    return ContestRepository.getActiveReminderContests(userId, "codeforces");
+  }
+
+  static async markReminderNotified(userId, contestId) {
+    await ContestRepository.markNotified(userId, "codeforces", contestId);
+    return { message: "Reminder marked as shown.", contestId };
+  }
+}
+
+export default ContestService;

--- a/server/modules/contests/validation.js
+++ b/server/modules/contests/validation.js
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+/** Validate req.body against a Zod schema and call next() or return 400 */
+export const validate = (schema) => (req, res, next) => {
+  const result = schema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: result.error.errors.map((e) => ({
+        field: e.path.join("."),
+        message: e.message,
+      })),
+    });
+  }
+  req.body = result.data;
+  next();
+};
+
+export const addReminderSchema = z.object({
+  contestId: z.coerce.number().int().positive(),
+});

--- a/server/modules/contests/validation.js
+++ b/server/modules/contests/validation.js
@@ -7,7 +7,7 @@ export const validate = (schema) => (req, res, next) => {
     return res.status(400).json({
       success: false,
       message: "Validation error",
-      errors: result.error.errors.map((e) => ({
+      errors: result.error.issues.map((e) => ({
         field: e.path.join("."),
         message: e.message,
       })),

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,6 +20,7 @@
         "express-rate-limit": "^8.5.2",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.3.3",
+        "node-cron": "^3.0.3",
         "nodemailer": "^8.0.4",
         "openai": "^6.33.0",
         "zod": "^4.3.6"
@@ -1478,6 +1479,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -2100,6 +2113,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "express-rate-limit": "^8.5.2",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.3.3",
+    "node-cron": "^3.0.3",
     "nodemailer": "^8.0.4",
     "openai": "^6.33.0",
     "zod": "^4.3.6"

--- a/server/server.js
+++ b/server/server.js
@@ -1,11 +1,15 @@
 import app from './app.js';
 import connectDB from './config/db.js';
 import './config/env.js';
+import { startContestSyncJob } from './jobs/contestSync.js';
 
 const PORT = process.env.PORT || 5000;
 
 const startServer = async () => {
   await connectDB();
+
+  startContestSyncJob();
+
   app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);
   });


### PR DESCRIPTION
# 📌 Pull Request Summary

## 🔗 Related Issue

Closes #253

---

## 📝 Description

Adds a real, live **Upcoming Contests Tracker for Codeforces** with in-app reminders, replacing the static placeholder content on `/contests/codeforces` with real data and wiring reminders through the dashboard and navbar.

### Changes Made

**Backend**
* New `Contest` model - caches Codeforces' `contest.list` response (id, name, phase, parsed division, start time, duration).
* New `ContestReminder` model - one doc per `(user, contest)` opt-in, with a `notifiedAt` flag so in-app toasts never repeat.
* New `contests` module (`routes` / `controller` / `service` / `repository` / `validation`) following the existing feature-module pattern used by `codeforces`:
  * `GET /api/contests/codeforces/upcoming` - public, returns cached upcoming/running contests.
  * `GET /api/contests/reminders` - a user's reminder contest ids.
  * `GET /api/contests/reminders/active` - full contest details for reminders (powers the badge/toast).
  * `POST /api/contests/reminders` / `DELETE /api/contests/reminders/:contestId` - set/unset a reminder.
  * `POST /api/contests/reminders/:contestId/notified` - mark a reminder's toast as shown.
* New `server/jobs/contestSync.js` - `node-cron` job that syncs the Codeforces contest list on startup and hourly, so the frontend never calls the CF API directly (avoids rate limits, keeps the page fast).
* Added `node-cron` dependency.

**Frontend**
* `useContests` hook - fetches cached contests, ticks a shared 1s clock for live countdowns, manages optimistic reminder toggling.
* `UpcomingContestsList` - division-filterable contest cards with live countdown + "Remind Me" toggle (used both full-size on the contest page and in `compact` mode elsewhere).
* `ContestCountdown` - pure countdown formatter (dd:hh:mm:ss / "Live Now").
* `UpcomingContestsWidget` - compact top-3 dashboard widget, added to `DashboardPage`.
* `ContestReminderBell` - navbar badge showing reminders due within 24h, linking to the tracker.
* `ContestReminderNotifier` - mounted once in `MainLayout`; polls reminders every 30s and pops an in-app toast when a reminder-contest starts within 15 minutes (persisted server-side so it survives reloads/navigation).
* `ContestCodeforcesPage` now leads with the live tracker, with the existing editorial archive section kept below it.

### Motivation

Issue #253 asked for a way to see upcoming Codeforces contests and get reminded about them without leaving CodeLens. This wires up real Codeforces data (cached and refreshed hourly server-side) end-to-end: dashboard widget → dedicated tracker page → reminder opt-in → navbar badge → in-app toast when a contest is about to start.

---

## 🚀 Type of Change

* [x] New Feature

---

## 🧪 Testing

### Verification

* [x] Tested Locally
* [x] No Testing Required *(no existing test suite in the repo for this module)*

### Test Details

* Ran `node --check` on every new/modified backend file, and smoke-imported `app.js` / the new `contests` routes module to confirm they load without errors.
* Ran `npm run lint` (ESLint) on all new/modified frontend files - zero new warnings/errors introduced (pre-existing, unrelated `Navbar.jsx` issues on `main` are untouched by this PR).
* Ran `npm run build` (Vite) - production build succeeds.
* Manually verified: contest list renders with live countdowns, division filter works, reminder toggle updates optimistically and persists, dashboard widget shows top 3 contests, navbar bell badge reflects reminders due soon, and the in-app toast fires within the 15-minute window and doesn't repeat.

---

## 📸 Screenshots / Demo (If Applicable)

https://github.com/user-attachments/assets/a47404b5-0fc7-474c-bc60-9a6b24e4766e

---

## ✅ Checklist

* [x] I have read and followed the contribution guidelines.
* [x] I have self-reviewed my changes.
* [x] My changes are limited to the scope of this issue.
* [x] Documentation has been updated where necessary.
* [x] No unnecessary files or unrelated changes have been included.
* [x] The related issue has been linked correctly.
* [x] All applicable testing and validation steps have been completed.

---

## 📚 Additional Notes

* Reminders and the notifier only require Codeforces (no OAuth to CF needed) — this uses the same public `contest.list` endpoint already wrapped in `server/utils/codeforcesApi.js`.
* The `Contest` model is intentionally keyed by `platform` so CodeChef/LeetCode/AtCoder trackers can reuse the same collection/module shape in a follow-up issue instead of duplicating it.
* `server/package-lock.json` is updated because `node-cron` was added as a dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Upcoming Contests” section on the Codeforces page and an “Upcoming Contests” widget on the dashboard.
  * Enhanced contest countdowns with Live Now, Ended, and day-aware `hh:mm:ss` formatting, plus a compact display mode.
  * Introduced contest reminders with a bell badge, reminder toggles on contest cards, and bottom-right “starting soon” notifications.
* **UI Improvements**
  * Refreshed the Codeforces page visuals with updated lucide icons and updated hero styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->