### PR TITLE
fix: add MongoDB-based distributed lock to contest sync cron job

### DIFF
--- a/server/jobs/contestSync.js
+++ b/server/jobs/contestSync.js
@@ -1,62 +1,109 @@
 import cron from "node-cron";
+import crypto from "node:crypto";
+import os from "node:os";
 import ContestService from "../modules/contests/service.js";
 import SyncLock from "../models/SyncLock.js";
 
 const JOB_NAME = "contestSync";
-const LOCK_TTL_MS = 5 * 60 * 1000; // 5 minutes — enough for a sync to finish
+// Must comfortably exceed the slowest expected sync duration — this is the
+// safety net that recovers the lease automatically if a holder crashes.
+const LOCK_TTL_MS = 10 * 60 * 1000;
+const INSTANCE_ID = `${os.hostname()}:${process.pid}`;
 
 /**
- * Atomically try to acquire the lock for this job. Returns true if this
- * instance won the lock and should run the sync, false otherwise.
+ * Chosen strategy: DB-backed lease (Option 2 in issue #277), since MongoDB
+ * is already a project dependency and requires no new infrastructure.
  *
- * The findOneAndUpdate below is a single atomic server-side operation, so
- * two instances racing to acquire the lock at the same moment cannot both
- * succeed. Only the instance whose write actually satisfies the filter
- * ({ lockedUntil: { $lt: now } } OR no doc yet) gets the updated document.
+ * - Acquisition is a single atomic findOneAndUpdate (no read-then-write race).
+ * - Each acquisition is tagged with a unique ownerId, so only the instance
+ *   that acquired the lease can release it early.
+ * - lockedUntil bounds how long a lease can be held, so a crashed or hung
+ *   holder cannot block future syncs indefinitely.
+ *
+ * Deployment note: this is safe for any topology sharing one MongoDB
+ * (PM2 cluster mode, container replicas, rolling deploys, multiple dynos).
+ * If the team later moves sync to a dedicated worker process (Option 1),
+ * this lock logic can be removed and the cron moved there exclusively.
  */
-const acquireLock = async (jobName, ttlMs) => {
+
+export const acquireLock = async (jobName, ttlMs, ownerId) => {
   const now = new Date();
   try {
-    await SyncLock.findOneAndUpdate(
+    const result = await SyncLock.findOneAndUpdate(
       { jobName, lockedUntil: { $lt: now } },
-      { jobName, lockedUntil: new Date(now.getTime() + ttlMs) },
+      { jobName, ownerId, lockedUntil: new Date(now.getTime() + ttlMs) },
       { upsert: true, returnDocument: "after" }
     );
-    return true;
+    return result?.ownerId === ownerId;
   } catch (err) {
-    // Duplicate key error (11000) means another instance won the race and
-    // upserted first — this is expected, not a real failure.
     if (err.code === 11000) {
+      // Another instance's upsert won the atomic race for this tick.
       return false;
     }
-    // Any other error (e.g. DB unreachable) should degrade gracefully:
-    // skip this tick rather than crash the process.
-    console.warn("[Contest Sync] Lock acquisition failed, skipping tick:", err.message);
+    console.warn(`[Contest Sync] Lock acquisition failed (${jobName}):`, err.message);
     return false;
+  }
+};
+
+/**
+ * Best-effort early release so the next tick (or another instance) doesn't
+ * have to wait out the full TTL. Scoped to ownerId — if the lease already
+ * expired and was taken over by someone else, this is a safe no-op.
+ */
+export const releaseLock = async (jobName, ownerId) => {
+  try {
+    await SyncLock.deleteOne({ jobName, ownerId });
+  } catch (err) {
+    // Non-fatal: the lease will simply expire naturally via TTL.
+    console.warn(`[Contest Sync] Lock release failed (${jobName}):`, err.message);
   }
 };
 
 export const startContestSyncJob = async () => {
   // Ensure the unique index on SyncLock.jobName is built before any lock
-  // acquisition happens — otherwise the very first concurrent upsert race
-  // (right after server boot) isn't guaranteed to be exclusive.
-  await SyncLock.init();
+  // acquisition happens. If this fails, contest sync is disabled for this
+  // process rather than taking down the whole server — sync is a
+  // background convenience, not a request-serving dependency.
+  try {
+    await SyncLock.init();
+  } catch (err) {
+    console.error("[Contest Sync] Failed to initialize SyncLock index — contest sync disabled for this instance:", err.message);
+    return;
+  }
+
+  // In-process guard: stops THIS instance from starting a second sync if
+  // the previous run is still in flight when the next tick fires.
+  let isRunning = false;
 
   const runSync = async () => {
-    const acquired = await acquireLock(JOB_NAME, LOCK_TTL_MS);
-    if (!acquired) {
-      console.log("[Contest Sync] Skipped — another instance holds the lock.");
+    const runId = crypto.randomUUID();
+
+    if (isRunning) {
+      console.log(`[Contest Sync] Skipped (run ${runId}) — previous sync on this instance is still in progress.`);
       return;
     }
 
+    const ownerId = `${INSTANCE_ID}:${runId}`;
+    const acquired = await acquireLock(JOB_NAME, LOCK_TTL_MS, ownerId);
+    if (!acquired) {
+      console.log(`[Contest Sync] Skipped (run ${runId}) — another instance holds the lease.`);
+      return;
+    }
+
+    isRunning = true;
+    console.log(`[Contest Sync] Acquired lease (run ${runId}, owner ${ownerId}) — starting sync.`);
+
     try {
       const { synced } = await ContestService.syncCodeforcesContests();
-      console.log(`[Contest Sync] Synced ${synced} Codeforces contest(s).`);
+      console.log(`[Contest Sync] Run ${runId} synced ${synced} Codeforces contest(s).`);
     } catch (err) {
-      console.error("[Contest Sync Error]", err.message);
+      console.error(`[Contest Sync] Run ${runId} failed:`, err.message);
+    } finally {
+      isRunning = false;
+      await releaseLock(JOB_NAME, ownerId);
     }
   };
 
-  runSync();
+  await runSync();
   cron.schedule("0 * * * *", runSync);
 };

--- a/server/jobs/contestSync.js
+++ b/server/jobs/contestSync.js
@@ -36,7 +36,12 @@ const acquireLock = async (jobName, ttlMs) => {
   }
 };
 
-export const startContestSyncJob = () => {
+export const startContestSyncJob = async () => {
+  // Ensure the unique index on SyncLock.jobName is built before any lock
+  // acquisition happens — otherwise the very first concurrent upsert race
+  // (right after server boot) isn't guaranteed to be exclusive.
+  await SyncLock.init();
+
   const runSync = async () => {
     const acquired = await acquireLock(JOB_NAME, LOCK_TTL_MS);
     if (!acquired) {

--- a/server/jobs/contestSync.js
+++ b/server/jobs/contestSync.js
@@ -1,8 +1,49 @@
 import cron from "node-cron";
 import ContestService from "../modules/contests/service.js";
+import SyncLock from "../models/SyncLock.js";
+
+const JOB_NAME = "contestSync";
+const LOCK_TTL_MS = 5 * 60 * 1000; // 5 minutes — enough for a sync to finish
+
+/**
+ * Atomically try to acquire the lock for this job. Returns true if this
+ * instance won the lock and should run the sync, false otherwise.
+ *
+ * The findOneAndUpdate below is a single atomic server-side operation, so
+ * two instances racing to acquire the lock at the same moment cannot both
+ * succeed. Only the instance whose write actually satisfies the filter
+ * ({ lockedUntil: { $lt: now } } OR no doc yet) gets the updated document.
+ */
+const acquireLock = async (jobName, ttlMs) => {
+  const now = new Date();
+  try {
+    await SyncLock.findOneAndUpdate(
+      { jobName, lockedUntil: { $lt: now } },
+      { jobName, lockedUntil: new Date(now.getTime() + ttlMs) },
+      { upsert: true, returnDocument: "after" }
+    );
+    return true;
+  } catch (err) {
+    // Duplicate key error (11000) means another instance won the race and
+    // upserted first — this is expected, not a real failure.
+    if (err.code === 11000) {
+      return false;
+    }
+    // Any other error (e.g. DB unreachable) should degrade gracefully:
+    // skip this tick rather than crash the process.
+    console.warn("[Contest Sync] Lock acquisition failed, skipping tick:", err.message);
+    return false;
+  }
+};
 
 export const startContestSyncJob = () => {
   const runSync = async () => {
+    const acquired = await acquireLock(JOB_NAME, LOCK_TTL_MS);
+    if (!acquired) {
+      console.log("[Contest Sync] Skipped — another instance holds the lock.");
+      return;
+    }
+
     try {
       const { synced } = await ContestService.syncCodeforcesContests();
       console.log(`[Contest Sync] Synced ${synced} Codeforces contest(s).`);

--- a/server/models/SyncLock.js
+++ b/server/models/SyncLock.js
@@ -12,6 +12,7 @@ import mongoose from "mongoose";
 const SyncLockSchema = new mongoose.Schema(
   {
     jobName: { type: String, unique: true, required: true },
+    ownerId: { type: String, required: true },
     lockedUntil: { type: Date, required: true },
   },
   { timestamps: true }

--- a/server/models/SyncLock.js
+++ b/server/models/SyncLock.js
@@ -1,0 +1,20 @@
+import mongoose from "mongoose";
+
+/**
+ * Distributed lock used to ensure only one running instance executes a
+ * given scheduled job (e.g. contest sync) per tick, even when the app is
+ * horizontally scaled across multiple processes/dynos.
+ *
+ * A doc is "locked" while `lockedUntil` is in the future. Acquiring the
+ * lock is a single atomic `findOneAndUpdate`, so there is no read-then-write
+ * race between instances.
+ */
+const SyncLockSchema = new mongoose.Schema(
+  {
+    jobName: { type: String, unique: true, required: true },
+    lockedUntil: { type: Date, required: true },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model("SyncLock", SyncLockSchema);

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,7 @@ const PORT = process.env.PORT || 5000;
 const startServer = async () => {
   await connectDB();
 
-  startContestSyncJob();
+  await startContestSyncJob();
 
   app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);


### PR DESCRIPTION
# 📌 Pull Request Summary

## 🔗 Related Issue
Closes #276

---

## 📝 Description

Provide a clear and concise summary of the changes made in this pull request.

### Changes Made
* Added a new `SyncLock` mongoose model (`server/models/SyncLock.js`) representing a distributed lock document keyed by `jobName`, with a `lockedUntil` expiry timestamp.
* Updated `server/jobs/contestSync.js` to atomically acquire the lock via `findOneAndUpdate` before running `syncCodeforcesContests()`. Only the instance that successfully acquires the lock runs the sync; all other instances skip that tick and log a message instead.
* Lock acquisition failures (e.g. DB unreachable, or another instance already holding the lock) degrade gracefully, the tick is skipped with a logged warning instead of the process crashing.
* No changes were needed to `server/server.js` - `startContestSyncJob()` is still called the same way; the guard lives inside the job itself.

### Motivation
`startContestSyncJob()` schedules an hourly `node-cron` job entirely in-process, with no coordination between multiple running instances. As reported by CodeRabbit during review of PR #269, once this app is horizontally scaled (multiple dynos/replicas/PM2 cluster workers), every instance would independently fire its own timer and run the full Codeforces sync at the same wall-clock minute, hitting the Codeforces API N times instead of once, and multiplying DB write load for zero benefit. This PR introduces a MongoDB-based distributed lock (using an existing dependency, no new infra) so that exactly one instance executes the sync per scheduled tick, regardless of instance count.

---

## 🚀 Type of Change

Select all that apply:
* [x] Bug Fix
* [ ] New Feature
* [ ] Enhancement
* [ ] Documentation Update
* [ ] Refactoring
* [ ] Performance Improvement
* [ ] DevOps / Tooling
* [ ] Other

---

## 🧪 Testing

### Verification
* [x] Tested Locally
* [ ] Existing Tests Passed
* [ ] New Tests Added
* [ ] No Testing Required

### Test Details
Ran two `node server.js` instances concurrently against the same MongoDB Atlas cluster to simulate horizontal scaling:
- First run: Terminal 1 logged `[Contest Sync] Synced 24 Codeforces contest(s).` while Terminal 2 logged `[Contest Sync] Skipped - another instance holds the lock.`, confirming exactly one instance executes the sync per tick.
- Verified the `synclocks` collection in MongoDB Atlas contains a single lock document per job (`jobName: "contestSync"`) with a `lockedUntil` expiry ~5 minutes ahead of `createdAt`.
- Also verified lock persistence across process restarts: restarting both instances while a prior lock was still valid correctly resulted in both instances skipping, confirming the lock is DB-backed (not just an in-memory guard) and survives process restarts.

---

## 📸 Screenshots / Demo (If Applicable)

Terminal 1:
<img width="1552" height="257" alt="Screenshot 2026-07-11 224857" src="https://github.com/user-attachments/assets/29704d7f-f3df-458d-a04d-2f140229182a" />

Terminal 2:
<img width="1546" height="213" alt="Screenshot 2026-07-11 224915" src="https://github.com/user-attachments/assets/dfc15136-8fc4-4bf0-b257-043888d58568" />

---

<img width="1421" height="311" alt="Screenshot 2026-07-11 224950" src="https://github.com/user-attachments/assets/e76fe991-9e32-429f-bedb-9f2670be2a0a" />

---

## ✅ Checklist
* [x] I have read and followed the contribution guidelines.
* [x] I have self-reviewed my changes.
* [x] My changes are limited to the scope of this issue.
* [ ] Documentation has been updated where necessary.
* [x] No unnecessary files or unrelated changes have been included.
* [x] The related issue has been linked correctly.
* [x] All applicable testing and validation steps have been completed.

---

## 📚 Additional Notes
Chose the MongoDB-based leader lock approach (option 1 from the issue) since MongoDB is already a project dependency and `findOneAndUpdate` provides the atomicity needed to avoid a read-then-write race condition between instances, no new infrastructure (e.g. Redis) required. Also fixed the `findOneAndUpdate` deprecation warning (`new: true` → `returnDocument: "after"`) encountered while implementing this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate contest synchronization when multiple application instances run concurrently by adding a database-backed distributed lock.
  * Improved scheduled job coordination and startup sequencing so contest sync runs only when exclusive access is available, skipping safely on contention and releasing the lock after completion/failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->