### PR TITLE
feat: harden contest sync lease with safe release, overlap guard, tests & docs

### DIFF
--- a/server/jobs/README.md
+++ b/server/jobs/README.md
@@ -12,15 +12,32 @@ running the actual sync, an instance must atomically acquire a lease in the
 - Only the instance holding the lease runs `syncCodeforcesContests()`.
 - The lease is released immediately after the run finishes (success or
   failure) so the next tick isn't blocked waiting on the full TTL.
-- If a holder crashes or hangs, the lease auto-expires after `LOCK_TTL_MS`
-  (currently 10 minutes) and the next tick on another instance can take over.
-- A per-instance in-memory flag additionally prevents the *same* instance
-  from starting an overlapping sync if one run takes longer than expected.
+- While a run is in progress, the lease is **periodically renewed**
+  (`renewLock`, every `RENEWAL_INTERVAL_MS` — currently half the TTL) so a
+  sync that legitimately runs longer than `LOCK_TTL_MS` does not lose its
+  lease to another instance mid-run. Renewal is scoped to the owning
+  instance's `ownerId`, so it can only ever extend a lease it actually
+  holds.
+- If a holder crashes or hangs — and therefore stops renewing — the lease
+  auto-expires after `LOCK_TTL_MS` (currently 10 minutes) and the next tick
+  on another instance can safely take over. This TTL expiry path is a
+  crash-recovery backstop only; under normal operation a healthy run keeps
+  renewing and never reaches it.
+- A per-instance in-memory flag (`isRunning`) additionally prevents the
+  *same* instance from starting an overlapping sync if one run takes longer
+  than expected.
 
 **Deployment implication:** no special configuration is needed to run this
 app with multiple replicas (PM2 cluster mode, container replicas, rolling
 deploys, multiple dynos) — all instances share one MongoDB and coordinate
 through it automatically.
+
+**Testability:** `createRunSync()` builds the scheduler's run function with
+all Mongo-facing dependencies (`acquire`, `release`, `renew`, `syncFn`)
+injectable, so every execution path — successful sync, failed sync (lock
+still released), skipped due to lock contention, and skipped due to
+same-instance overlap — is covered by fast, deterministic unit tests in
+`contestSync.test.js` with no real database required.
 
 **If this ever needs to change:** if sync duration grows significantly, or
 side effects become non-idempotent (emails, push notifications), consider
@@ -34,5 +51,6 @@ To manually confirm the lease behaves correctly with multiple instances:
 2. Confirm one logs `Acquired lease ... starting sync` and the other logs
    `Skipped ... another instance holds the lease`.
 3. Check the `synclocks` collection has exactly one document for
-   `jobName: "contestSync"`.
+   `jobName: "contestSync"`, and that it disappears shortly after the
+   winning instance's run finishes.
    

--- a/server/jobs/README.md
+++ b/server/jobs/README.md
@@ -1,0 +1,38 @@
+# Scheduled Jobs
+
+## Contest sync (`contestSync.js`)
+
+**Strategy:** Database-backed lease (MongoDB), not a dedicated worker process or queue.
+
+Every backend instance calls `startContestSyncJob()` on boot. Each instance
+independently registers the same hourly `node-cron` schedule, but before
+running the actual sync, an instance must atomically acquire a lease in the
+`synclocks` collection (`SyncLock` model, `jobName: "contestSync"`).
+
+- Only the instance holding the lease runs `syncCodeforcesContests()`.
+- The lease is released immediately after the run finishes (success or
+  failure) so the next tick isn't blocked waiting on the full TTL.
+- If a holder crashes or hangs, the lease auto-expires after `LOCK_TTL_MS`
+  (currently 10 minutes) and the next tick on another instance can take over.
+- A per-instance in-memory flag additionally prevents the *same* instance
+  from starting an overlapping sync if one run takes longer than expected.
+
+**Deployment implication:** no special configuration is needed to run this
+app with multiple replicas (PM2 cluster mode, container replicas, rolling
+deploys, multiple dynos) — all instances share one MongoDB and coordinate
+through it automatically.
+
+**If this ever needs to change:** if sync duration grows significantly, or
+side effects become non-idempotent (emails, push notifications), consider
+moving to a dedicated worker/scheduler process (see issue #277, Option 1)
+so web instances are no longer cron owners at all.
+
+## Local validation
+
+To manually confirm the lease behaves correctly with multiple instances:
+1. Run `node server.js` in two terminals against the same MongoDB.
+2. Confirm one logs `Acquired lease ... starting sync` and the other logs
+   `Skipped ... another instance holds the lease`.
+3. Check the `synclocks` collection has exactly one document for
+   `jobName: "contestSync"`.
+   

--- a/server/jobs/contestSync.js
+++ b/server/jobs/contestSync.js
@@ -6,8 +6,13 @@ import SyncLock from "../models/SyncLock.js";
 
 const JOB_NAME = "contestSync";
 // Must comfortably exceed the slowest expected sync duration — this is the
-// safety net that recovers the lease automatically if a holder crashes.
+// safety net that recovers the lease automatically if a holder crashes or
+// hangs. Renewal (below) keeps this from ever being hit during a healthy
+// long-running sync; it's purely a recovery backstop.
 const LOCK_TTL_MS = 10 * 60 * 1000;
+// Renew at half the TTL so a renewal can be missed once (e.g. one slow
+// Mongo round trip) without the lease lapsing before the next attempt.
+const RENEWAL_INTERVAL_MS = LOCK_TTL_MS / 2;
 const INSTANCE_ID = `${os.hostname()}:${process.pid}`;
 
 /**
@@ -16,9 +21,14 @@ const INSTANCE_ID = `${os.hostname()}:${process.pid}`;
  *
  * - Acquisition is a single atomic findOneAndUpdate (no read-then-write race).
  * - Each acquisition is tagged with a unique ownerId, so only the instance
- *   that acquired the lease can release it early.
- * - lockedUntil bounds how long a lease can be held, so a crashed or hung
- *   holder cannot block future syncs indefinitely.
+ *   that acquired the lease can release or renew it.
+ * - lockedUntil bounds how long a lease can be held without renewal, so a
+ *   crashed or hung holder cannot block future syncs indefinitely.
+ * - While a sync is actively running, the lease is periodically RENEWED
+ *   (see RENEWAL_INTERVAL_MS) so a run that legitimately takes longer than
+ *   LOCK_TTL_MS does not lose its lease to another instance mid-run. Only a
+ *   holder that has actually crashed/hung (and therefore stopped renewing)
+ *   ever lets the TTL lapse.
  *
  * Deployment note: this is safe for any topology sharing one MongoDB
  * (PM2 cluster mode, container replicas, rolling deploys, multiple dynos).
@@ -46,6 +56,25 @@ export const acquireLock = async (jobName, ttlMs, ownerId) => {
 };
 
 /**
+ * Extends the current lease while a run is still active. Scoped to
+ * jobName + ownerId so this can only ever renew a lease this instance
+ * actually holds — it is a no-op (not an error) if the lease was already
+ * lost (e.g. renewal was missed for an entire TTL window and another
+ * instance took over).
+ */
+export const renewLock = async (jobName, ttlMs, ownerId) => {
+  try {
+    const now = new Date();
+    await SyncLock.updateOne(
+      { jobName, ownerId },
+      { lockedUntil: new Date(now.getTime() + ttlMs) }
+    );
+  } catch (err) {
+    console.warn(`[Contest Sync] Lock renewal failed (${jobName}):`, err.message);
+  }
+};
+
+/**
  * Best-effort early release so the next tick (or another instance) doesn't
  * have to wait out the full TTL. Scoped to ownerId — if the lease already
  * expired and was taken over by someone else, this is a safe no-op.
@@ -57,6 +86,66 @@ export const releaseLock = async (jobName, ownerId) => {
     // Non-fatal: the lease will simply expire naturally via TTL.
     console.warn(`[Contest Sync] Lock release failed (${jobName}):`, err.message);
   }
+};
+
+/**
+ * Builds a single, stateful runSync function. All Mongo/side-effecting
+ * dependencies are injectable so the scheduler's execution paths (synced,
+ * failed-with-release, skipped-locked, skipped-running) can be tested
+ * deterministically without a real database or cron.
+ *
+ * Returns the runner function AND exposes getIsRunning for tests that
+ * need to assert on in-flight state.
+ */
+export const createRunSync = ({
+  jobName,
+  ttlMs,
+  renewalIntervalMs,
+  instanceId,
+  syncFn,
+  acquire = acquireLock,
+  release = releaseLock,
+  renew = renewLock,
+}) => {
+  let isRunning = false;
+
+  const runSync = async () => {
+    const runId = crypto.randomUUID();
+
+    if (isRunning) {
+      console.log(`[Contest Sync] Skipped (run ${runId}) — previous sync on this instance is still in progress.`);
+      return { outcome: "skipped-running", runId };
+    }
+
+    const ownerId = `${instanceId}:${runId}`;
+    const acquired = await acquire(jobName, ttlMs, ownerId);
+    if (!acquired) {
+      console.log(`[Contest Sync] Skipped (run ${runId}) — another instance holds the lease.`);
+      return { outcome: "skipped-locked", runId };
+    }
+
+    isRunning = true;
+    console.log(`[Contest Sync] Acquired lease (run ${runId}, owner ${ownerId}) — starting sync.`);
+
+    const heartbeat = setInterval(() => {
+      renew(jobName, ttlMs, ownerId);
+    }, renewalIntervalMs);
+
+    try {
+      const { synced } = await syncFn();
+      console.log(`[Contest Sync] Run ${runId} synced ${synced} Codeforces contest(s).`);
+      return { outcome: "synced", runId, synced };
+    } catch (err) {
+      console.error(`[Contest Sync] Run ${runId} failed:`, err.message);
+      return { outcome: "failed", runId, error: err.message };
+    } finally {
+      clearInterval(heartbeat);
+      isRunning = false;
+      await release(jobName, ownerId);
+    }
+  };
+
+  return { runSync, getIsRunning: () => isRunning };
 };
 
 export const startContestSyncJob = async () => {
@@ -71,38 +160,13 @@ export const startContestSyncJob = async () => {
     return;
   }
 
-  // In-process guard: stops THIS instance from starting a second sync if
-  // the previous run is still in flight when the next tick fires.
-  let isRunning = false;
-
-  const runSync = async () => {
-    const runId = crypto.randomUUID();
-
-    if (isRunning) {
-      console.log(`[Contest Sync] Skipped (run ${runId}) — previous sync on this instance is still in progress.`);
-      return;
-    }
-
-    const ownerId = `${INSTANCE_ID}:${runId}`;
-    const acquired = await acquireLock(JOB_NAME, LOCK_TTL_MS, ownerId);
-    if (!acquired) {
-      console.log(`[Contest Sync] Skipped (run ${runId}) — another instance holds the lease.`);
-      return;
-    }
-
-    isRunning = true;
-    console.log(`[Contest Sync] Acquired lease (run ${runId}, owner ${ownerId}) — starting sync.`);
-
-    try {
-      const { synced } = await ContestService.syncCodeforcesContests();
-      console.log(`[Contest Sync] Run ${runId} synced ${synced} Codeforces contest(s).`);
-    } catch (err) {
-      console.error(`[Contest Sync] Run ${runId} failed:`, err.message);
-    } finally {
-      isRunning = false;
-      await releaseLock(JOB_NAME, ownerId);
-    }
-  };
+  const { runSync } = createRunSync({
+    jobName: JOB_NAME,
+    ttlMs: LOCK_TTL_MS,
+    renewalIntervalMs: RENEWAL_INTERVAL_MS,
+    instanceId: INSTANCE_ID,
+    syncFn: () => ContestService.syncCodeforcesContests(),
+  });
 
   await runSync();
   cron.schedule("0 * * * *", runSync);

--- a/server/jobs/contestSync.test.js
+++ b/server/jobs/contestSync.test.js
@@ -1,0 +1,80 @@
+import { test, describe, mock, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import SyncLock from "../models/SyncLock.js";
+import { acquireLock, releaseLock } from "./contestSync.js";
+
+describe("contestSync distributed lock", () => {
+  beforeEach(() => {
+    mock.restoreAll();
+  });
+
+  test("acquires the lock when no unexpired lease exists", async () => {
+    mock.method(SyncLock, "findOneAndUpdate", async (filter, update) => ({
+      jobName: update.jobName,
+      ownerId: update.ownerId,
+      lockedUntil: update.lockedUntil,
+    }));
+
+    const acquired = await acquireLock("contestSync", 60000, "instanceA:run1");
+    assert.equal(acquired, true);
+  });
+
+  test("only one of two concurrent acquirers wins (duplicate key race)", async () => {
+    let firstCallWon = false;
+    mock.method(SyncLock, "findOneAndUpdate", async (filter, update) => {
+      if (!firstCallWon) {
+        firstCallWon = true;
+        return { jobName: update.jobName, ownerId: update.ownerId, lockedUntil: update.lockedUntil };
+      }
+      const err = new Error("E11000 duplicate key error");
+      err.code = 11000;
+      throw err;
+    });
+
+    const [a, b] = await Promise.all([
+      acquireLock("contestSync", 60000, "instanceA:run1"),
+      acquireLock("contestSync", 60000, "instanceB:run1"),
+    ]);
+
+    assert.equal([a, b].filter(Boolean).length, 1);
+  });
+
+  test("returns false and does not throw when the DB is unreachable", async () => {
+    mock.method(SyncLock, "findOneAndUpdate", async () => {
+      throw new Error("connection timed out");
+    });
+
+    const acquired = await acquireLock("contestSync", 60000, "instanceA:run1");
+    assert.equal(acquired, false);
+  });
+
+  test("a new owner can acquire once the previous lease has expired", async () => {
+    mock.method(SyncLock, "findOneAndUpdate", async (filter, update) => ({
+      jobName: update.jobName,
+      ownerId: update.ownerId,
+      lockedUntil: update.lockedUntil,
+    }));
+
+    const acquired = await acquireLock("contestSync", 60000, "instanceB:run2");
+    assert.equal(acquired, true);
+  });
+
+  test("releaseLock deletes scoped to jobName + ownerId only", async () => {
+    let deleteFilter;
+    mock.method(SyncLock, "deleteOne", async (filter) => {
+      deleteFilter = filter;
+      return { deletedCount: 1 };
+    });
+
+    await releaseLock("contestSync", "instanceA:run1");
+    assert.deepEqual(deleteFilter, { jobName: "contestSync", ownerId: "instanceA:run1" });
+  });
+
+  test("releaseLock does not throw when deleteOne fails", async () => {
+    mock.method(SyncLock, "deleteOne", async () => {
+      throw new Error("connection lost");
+    });
+
+    await assert.doesNotReject(releaseLock("contestSync", "instanceA:run1"));
+  });
+});

--- a/server/jobs/contestSync.test.js
+++ b/server/jobs/contestSync.test.js
@@ -1,12 +1,10 @@
 import { test, describe, mock, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import SyncLock from "../models/SyncLock.js";
-import { acquireLock, releaseLock } from "./contestSync.js";
+import { acquireLock, releaseLock, renewLock, createRunSync } from "./contestSync.js";
 
-describe("contestSync distributed lock", () => {
-  beforeEach(() => {
-    mock.restoreAll();
-  });
+describe("acquireLock / releaseLock / renewLock", () => {
+  beforeEach(() => mock.restoreAll());
 
   test("acquires the lock when no unexpired lease exists", async () => {
     mock.method(SyncLock, "findOneAndUpdate", async (filter, update) => ({
@@ -48,15 +46,21 @@ describe("contestSync distributed lock", () => {
     assert.equal(acquired, false);
   });
 
-  test("a new owner can acquire once the previous lease has expired", async () => {
-    mock.method(SyncLock, "findOneAndUpdate", async (filter, update) => ({
-      jobName: update.jobName,
-      ownerId: update.ownerId,
-      lockedUntil: update.lockedUntil,
-    }));
+  test("acquireLock's query filter actually enforces lease expiry (lockedUntil $lt now)", async () => {
+    let capturedFilter;
+    mock.method(SyncLock, "findOneAndUpdate", async (filter, update) => {
+      capturedFilter = filter;
+      return { jobName: update.jobName, ownerId: update.ownerId, lockedUntil: update.lockedUntil };
+    });
 
-    const acquired = await acquireLock("contestSync", 60000, "instanceB:run2");
-    assert.equal(acquired, true);
+    await acquireLock("contestSync", 60000, "instanceB:run2");
+
+    assert.equal(capturedFilter.jobName, "contestSync");
+    assert.ok(capturedFilter.lockedUntil, "expected a lockedUntil predicate in the query filter");
+    assert.ok(
+      capturedFilter.lockedUntil.$lt instanceof Date,
+      "expected lockedUntil.$lt to be a Date so only expired/absent leases match"
+    );
   });
 
   test("releaseLock deletes scoped to jobName + ownerId only", async () => {
@@ -76,5 +80,168 @@ describe("contestSync distributed lock", () => {
     });
 
     await assert.doesNotReject(releaseLock("contestSync", "instanceA:run1"));
+  });
+
+  test("renewLock updates scoped to jobName + ownerId only, and does not throw on failure", async () => {
+    let updateFilter;
+    mock.method(SyncLock, "updateOne", async (filter) => {
+      updateFilter = filter;
+      return { matchedCount: 1 };
+    });
+
+    await renewLock("contestSync", 60000, "instanceA:run1");
+    assert.deepEqual(updateFilter, { jobName: "contestSync", ownerId: "instanceA:run1" });
+
+    mock.method(SyncLock, "updateOne", async () => {
+      throw new Error("connection lost");
+    });
+    await assert.doesNotReject(renewLock("contestSync", 60000, "instanceA:run1"));
+  });
+});
+
+describe("createRunSync — scheduler execution paths", () => {
+  test("synced: acquires, runs syncFn, releases on success", async () => {
+    const calls = [];
+    const acquire = async () => { calls.push("acquire"); return true; };
+    const release = async () => { calls.push("release"); };
+    const renew = async () => { calls.push("renew"); };
+    const syncFn = async () => ({ synced: 5 });
+
+    const { runSync, getIsRunning } = createRunSync({
+      jobName: "contestSync",
+      ttlMs: 60000,
+      renewalIntervalMs: 30000,
+      instanceId: "test-instance",
+      syncFn,
+      acquire,
+      release,
+      renew,
+    });
+
+    const result = await runSync();
+
+    assert.equal(result.outcome, "synced");
+    assert.equal(result.synced, 5);
+    assert.deepEqual(calls, ["acquire", "release"]);
+    assert.equal(getIsRunning(), false);
+  });
+
+  test("failed: syncFn throws, lock is still released (finally block)", async () => {
+    const calls = [];
+    const acquire = async () => true;
+    const release = async () => { calls.push("release"); };
+    const renew = async () => {};
+    const syncFn = async () => { throw new Error("Codeforces API unreachable"); };
+
+    const { runSync, getIsRunning } = createRunSync({
+      jobName: "contestSync",
+      ttlMs: 60000,
+      renewalIntervalMs: 30000,
+      instanceId: "test-instance",
+      syncFn,
+      acquire,
+      release,
+      renew,
+    });
+
+    const result = await runSync();
+
+    assert.equal(result.outcome, "failed");
+    assert.match(result.error, /Codeforces API unreachable/);
+    assert.deepEqual(calls, ["release"]);
+    assert.equal(getIsRunning(), false);
+  });
+
+  test("skipped-locked: another instance holds the lease, syncFn never runs", async () => {
+    let syncFnCalled = false;
+    const acquire = async () => false;
+    const release = async () => { throw new Error("release should never be called here"); };
+    const renew = async () => {};
+    const syncFn = async () => { syncFnCalled = true; return { synced: 0 }; };
+
+    const { runSync } = createRunSync({
+      jobName: "contestSync",
+      ttlMs: 60000,
+      renewalIntervalMs: 30000,
+      instanceId: "test-instance",
+      syncFn,
+      acquire,
+      release,
+      renew,
+    });
+
+    const result = await runSync();
+
+    assert.equal(result.outcome, "skipped-locked");
+    assert.equal(syncFnCalled, false);
+  });
+
+  test("skipped-running: a second call while the first is still in-flight on the same instance is skipped", async () => {
+    let resolveFirstSync;
+    const firstSyncGate = new Promise((resolve) => { resolveFirstSync = resolve; });
+    let syncFnCallCount = 0;
+
+    const acquire = async () => true;
+    const release = async () => {};
+    const renew = async () => {};
+    const syncFn = async () => {
+      syncFnCallCount += 1;
+      await firstSyncGate;
+      return { synced: 1 };
+    };
+
+    const { runSync, getIsRunning } = createRunSync({
+      jobName: "contestSync",
+      ttlMs: 60000,
+      renewalIntervalMs: 30000,
+      instanceId: "test-instance",
+      syncFn,
+      acquire,
+      release,
+      renew,
+    });
+
+    const firstRunPromise = runSync();
+    // Give the first call a tick to set isRunning = true before firing the second.
+    await new Promise((r) => setImmediate(r));
+    assert.equal(getIsRunning(), true);
+
+    const secondResult = await runSync();
+    assert.equal(secondResult.outcome, "skipped-running");
+    assert.equal(syncFnCallCount, 1, "syncFn should only have been invoked once");
+
+    resolveFirstSync();
+    const firstResult = await firstRunPromise;
+    assert.equal(firstResult.outcome, "synced");
+  });
+
+  test("renew is called periodically while a long-running sync is in flight", async () => {
+    let renewCount = 0;
+    const acquire = async () => true;
+    const release = async () => {};
+    const renew = async () => { renewCount += 1; };
+    let resolveSync;
+    const syncFn = async () => {
+      await new Promise((resolve) => { resolveSync = resolve; });
+      return { synced: 1 };
+    };
+
+    const { runSync } = createRunSync({
+      jobName: "contestSync",
+      ttlMs: 100,
+      renewalIntervalMs: 20, // short interval so the test doesn't need to wait long
+      instanceId: "test-instance",
+      syncFn,
+      acquire,
+      release,
+      renew,
+    });
+
+    const runPromise = runSync();
+    await new Promise((r) => setTimeout(r, 70)); // long enough for a few renewals to fire
+    resolveSync();
+    await runPromise;
+
+    assert.ok(renewCount >= 2, `expected at least 2 renewals, got ${renewCount}`);
   });
 });

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
# 📌 Pull Request Summary

## 🔗 Related Issue
Closes #277

---

## 📝 Description

### Changes Made
* Added `ownerId` to the `SyncLock` model so a lease is tagged with exactly which instance/run acquired it, allowing safe, scoped release that can never delete another instance's active lease.
* Updated `server/jobs/contestSync.js` to release the lease immediately after each run completes (success or failure) instead of relying solely on TTL expiry, so the next legitimate run doesn't wait unnecessarily.
* Added an in-process `isRunning` guard so a single instance cannot start an overlapping sync if a previous run is still in flight when the next scheduled tick fires.
* Improved logging to include a run ID and owner ID per attempt, clearly distinguishing acquired / skipped / succeeded / failed outcomes for easier debugging in production.
* Added automated tests (`server/jobs/contestSync.test.js`, using Node's built-in `node:test` runner) covering concurrent lock acquisition, DB-unreachable degradation, lease handoff after expiry, and owner-scoped release.
* Documented the chosen distributed-lease strategy and its deployment implications in `server/jobs/README.md`.
* Wired up `npm test` (`node --test`) since the repo had no test runner configured yet.

### Motivation
This is a follow-up to #276 covering the full **High**-severity finding from the review of #269: an in-process cron scheduler has no leader-election or distributed-lock mechanism, so every backend replica independently runs its own schedule. #276 introduced a basic TTL-based lock, but this issue requires the harder production-safety guarantees called out in its acceptance criteria, safe lock release scoped to the correct owner, protection against overlapping runs on the same instance, recovery from a crashed lock holder, and test/documentation coverage, none of which #276 addressed on its own. This PR closes those gaps so the contest sync job is safe to run across any number of replicas without multiplying external API calls, DB writes, or log noise.

---

## 🚀 Type of Change

Select all that apply:
* [x] Bug Fix
* [ ] New Feature
* [x] Enhancement
* [x] Documentation Update
* [ ] Refactoring
* [ ] Performance Improvement
* [ ] DevOps / Tooling
* [ ] Other

---

## 🧪 Testing

### Verification
* [x] Tested Locally
* [ ] Existing Tests Passed
* [x] New Tests Added
* [ ] No Testing Required

### Test Details
- **Automated:** Added 6 unit tests via `node --test`, covering: successful lock acquisition, concurrent acquirers racing for the same lease (only one wins via duplicate-key handling), graceful `false` return (no throw) when the DB is unreachable, reacquisition after lease handoff, owner-scoped `releaseLock` deletion, and `releaseLock` not throwing on DB failure. All 6 pass.
- **Manual - true concurrency:** Temporarily added an artificial delay inside the sync to widen the race window, then started two `node server.js` instances against the same MongoDB within that window. Instance 1 logged `Acquired lease ... starting sync` → `synced 24 contest(s)`; Instance 2 logged only `Skipped ... another instance holds the lease.` with no acquire/sync lines, confirming exclusivity under real concurrency. Delay was removed before committing.
- **Manual - prompt release:** Ran two instances sequentially; the second instance acquired a **new** lease immediately after the first released (not after waiting out the 10-minute TTL), confirming release-on-completion works correctly.
- **Manual - lock document:** Verified in MongoDB Atlas that the `synclocks` collection holds exactly one document for `jobName: "contestSync"`, and that it is removed immediately after a successful run rather than persisting for the full TTL window.

---

## 📸 Screenshots / Demo (If Applicable)

Terminal 1 & 2:

<img width="1517" height="317" alt="image" src="https://github.com/user-attachments/assets/a9a9546d-0482-49cf-8ed6-7cd5f57565f7" />

npm test:

<img width="1518" height="477" alt="image" src="https://github.com/user-attachments/assets/45a55294-2c48-476a-8bca-cc6850545259" />

---

## ✅ Checklist
* [x] I have read and followed the contribution guidelines.
* [x] I have self-reviewed my changes.
* [x] My changes are limited to the scope of this issue.
* [x] Documentation has been updated where necessary.
* [x] No unnecessary files or unrelated changes have been included.
* [x] The related issue has been linked correctly.
* [x] All applicable testing and validation steps have been completed.

---

## 📚 Additional Notes
This PR is based on top of the `fix/contest-sync-distributed-lock` branch from #276 rather than `main`, since it extends that work directly, please merge #276 first (or review this PR's diff against that branch) to avoid seeing unrelated changes. The chosen approach is a MongoDB-backed lease (Option 2 from the issue) rather than a dedicated worker process or queue, since it requires no new infrastructure; the tradeoffs and a migration path to a dedicated worker are documented in `server/jobs/README.md` for future reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deployment and troubleshooting guidance for reliable contest synchronization across multiple server instances.
  * Included steps for manually verifying lock and failover behavior.

* **Tests**
  * Added coverage for lock acquisition, expiration, concurrent execution, release behavior, and database failures.
  * Updated the test command to run the automated test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->