### PR TITLE
fix: harden contest lifecycle reconciliation, reminder polling, and category filtering

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,8 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@tailwindcss/typography": "^0.5.19",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -29,8 +31,68 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
-        "vite": "^8.0.14"
+        "jsdom": "^29.1.1",
+        "vite": "^8.0.14",
+        "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -224,6 +286,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -270,6 +342,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -458,6 +683,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1151,6 +1394,85 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1159,6 +1481,25 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -1232,6 +1573,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1342,6 +1690,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1394,6 +1855,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1416,6 +1888,26 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1463,6 +1955,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1562,6 +2064,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1714,6 +2226,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1854,6 +2387,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1870,6 +2417,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -1937,6 +2491,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1971,6 +2533,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1988,6 +2563,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2233,6 +2815,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2248,6 +2840,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2627,6 +3229,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -2695,6 +3310,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inline-style-parser": {
@@ -2791,6 +3416,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2825,6 +3457,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -3199,6 +3882,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3369,6 +4063,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -3833,6 +4534,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -3898,6 +4609,20 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3987,6 +4712,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4006,6 +4744,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4076,6 +4821,44 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -4252,6 +5035,20 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -4298,6 +5095,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reselect": {
@@ -4355,6 +5162,19 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4400,6 +5220,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4419,6 +5246,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -4431,6 +5272,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -4477,6 +5331,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -4502,6 +5363,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -4516,6 +5394,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -4555,6 +5489,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unified": {
@@ -4828,6 +5772,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4844,6 +5926,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4853,6 +5952,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
@@ -24,6 +25,8 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@tailwindcss/typography": "^0.5.19",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
@@ -31,6 +34,8 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
-    "vite": "^8.0.14"
+    "jsdom": "^29.1.1",
+    "vite": "^8.0.14",
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/src/components/contests/ContestCountdown.jsx
+++ b/frontend/src/components/contests/ContestCountdown.jsx
@@ -1,12 +1,12 @@
 import { Radio } from "lucide-react";
 
 /**
- * Renders a live "dd:hh:mm:ss" style countdown, or a running/finished label.
- * `msUntilStart` and `isRunning` come from `useContests` and are recomputed
- * every second from a single shared clock (see the hook) — this component
- * just formats them, it doesn't run its own timer.
+ * Renders a live "dd:hh:mm:ss" style countdown, or a running/testing/finished
+ * label. `msUntilStart`, `isRunning`, and `isTesting` come from `useContests`
+ * and are derived from the backend's authoritative `phase` field — this
+ * component just formats them, it doesn't decide run state itself.
  */
-export default function ContestCountdown({ msUntilStart, isRunning, compact = false }) {
+export default function ContestCountdown({ msUntilStart, isRunning, isTesting, compact = false }) {
   if (isRunning) {
     return (
       <span
@@ -20,9 +20,20 @@ export default function ContestCountdown({ msUntilStart, isRunning, compact = fa
     );
   }
 
-  // msUntilStart <= 0 with isRunning false means "now" is past both the start
-  // AND the end of the contest window — i.e. it has actually finished, not
-  // that it's about to start.
+  if (isTesting) {
+    return (
+      <span
+        className={`font-black text-amber-600 uppercase tracking-widest ${
+          compact ? "text-[10px]" : "text-sm"
+        }`}
+      >
+        System Testing
+      </span>
+    );
+  }
+
+  // msUntilStart <= 0 with isRunning/isTesting both false means the contest
+  // has actually finished, not that it's about to start.
   if (msUntilStart <= 0) {
     return (
       <span

--- a/frontend/src/components/contests/ContestReminderBell.jsx
+++ b/frontend/src/components/contests/ContestReminderBell.jsx
@@ -1,49 +1,26 @@
-import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Bell } from "lucide-react";
 import { useAuth } from "../../context/AuthContext";
-import { getMyActiveReminders } from "../../services/contestService";
+import { useReminders } from "../../context/ReminderContext";
 
-const POLL_INTERVAL_MS = 60_000; // 1 minute — reminders don't need second-level freshness
 const DUE_SOON_WINDOW_MS = 24 * 60 * 60 * 1000; // badge counts contests starting in <24h
 
 /**
  * Small navbar bell badge — shows how many reminders the user has set for
  * contests starting within the next 24 hours. Links through to the full
- * tracker page. Renders nothing while there's nothing to show.
+ * tracker page. Data comes from the shared ReminderProvider (see
+ * ReminderContext.jsx) rather than its own polling loop.
  */
 export default function ContestReminderBell() {
   const { isAuthenticated } = useAuth();
-  const [dueSoonCount, setDueSoonCount] = useState(0);
-
-  useEffect(() => {
-    if (!isAuthenticated) return;
-
-    let cancelled = false;
-
-    const poll = async () => {
-      try {
-        const { data } = await getMyActiveReminders();
-        if (cancelled) return;
-        const now = Date.now();
-        const dueSoon = (data.data || []).filter(
-          (c) => c.startTimeSeconds * 1000 - now < DUE_SOON_WINDOW_MS
-        );
-        setDueSoonCount(dueSoon.length);
-      } catch {
-        // Silent — the bell just won't update this cycle.
-      }
-    };
-
-    poll();
-    const id = setInterval(poll, POLL_INTERVAL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(id);
-    };
-  }, [isAuthenticated]);
+  const { reminders } = useReminders();
 
   if (!isAuthenticated) return null;
+
+  const now = Date.now();
+  const dueSoonCount = reminders.filter(
+    (c) => c.startTimeSeconds * 1000 - now < DUE_SOON_WINDOW_MS
+  ).length;
 
   return (
     <Link

--- a/frontend/src/components/contests/ContestReminderBell.jsx
+++ b/frontend/src/components/contests/ContestReminderBell.jsx
@@ -5,12 +5,6 @@ import { useReminders } from "../../context/ReminderContext";
 
 const DUE_SOON_WINDOW_MS = 24 * 60 * 60 * 1000; // badge counts contests starting in <24h
 
-/**
- * Small navbar bell badge — shows how many reminders the user has set for
- * contests starting within the next 24 hours. Links through to the full
- * tracker page. Data comes from the shared ReminderProvider (see
- * ReminderContext.jsx) rather than its own polling loop.
- */
 export default function ContestReminderBell() {
   const { isAuthenticated } = useAuth();
   const { reminders } = useReminders();
@@ -18,9 +12,10 @@ export default function ContestReminderBell() {
   if (!isAuthenticated) return null;
 
   const now = Date.now();
-  const dueSoonCount = reminders.filter(
-    (c) => c.startTimeSeconds * 1000 - now < DUE_SOON_WINDOW_MS
-  ).length;
+  const dueSoonCount = reminders.filter((c) => {
+    const msUntilStart = c.startTimeSeconds * 1000 - now;
+    return msUntilStart > 0 && msUntilStart < DUE_SOON_WINDOW_MS;
+  }).length;
 
   return (
     <Link

--- a/frontend/src/components/contests/UpcomingContestsList.jsx
+++ b/frontend/src/components/contests/UpcomingContestsList.jsx
@@ -5,7 +5,19 @@ import { useAuth } from "../../context/AuthContext";
 import { useContests } from "../../hooks/useContests";
 import ContestCountdown from "./ContestCountdown";
 
-const DIVISIONS = ["all", "Div. 1", "Div. 2", "Div. 3", "Div. 4", "Educational", "Global"];
+const DIVISIONS = [
+  "all",
+  "Div. 1",
+  "Div. 2",
+  "Div. 1 + 2",
+  "Div. 3",
+  "Div. 4",
+  "Educational",
+  "Global",
+  "Kotlin Heroes",
+  "ICPC",
+  "Other",
+];
 
 function formatStartTime(startTimeSeconds) {
   return new Date(startTimeSeconds * 1000).toLocaleString(undefined, {
@@ -135,6 +147,7 @@ export default function UpcomingContestsList({ compact = false, limit = 3 }) {
               <ContestCountdown
                 msUntilStart={contest.msUntilStart}
                 isRunning={contest.isRunning}
+                isTesting={contest.isTesting}
                 compact={compact}
               />
             </div>

--- a/frontend/src/components/shared/ContestReminderNotifier.jsx
+++ b/frontend/src/components/shared/ContestReminderNotifier.jsx
@@ -1,62 +1,58 @@
 import { useState, useEffect, useRef } from "react";
 import { Bell, X } from "lucide-react";
 import { useAuth } from "../../context/AuthContext";
-import { getMyActiveReminders, markReminderNotified } from "../../services/contestService";
+import { useReminders } from "../../context/ReminderContext";
+import { markReminderNotified } from "../../services/contestService";
+import { createReminderChannel } from "../../utils/reminderBroadcast";
 
-const POLL_INTERVAL_MS = 30_000; // 30s — frequent enough to catch the reminder window
 const REMINDER_WINDOW_MS = 15 * 60 * 1000; // toast fires when a contest starts within 15 minutes
 
 /**
- * Mounted once in MainLayout. While the user is active on the platform and
- * signed in, polls their contest reminders and pops an in-app toast when a
- * reminder-contest is starting within REMINDER_WINDOW_MS. Each reminder only
+ * Mounted once in MainLayout. Reads reminders from the shared
+ * ReminderProvider (see ReminderContext.jsx) — no polling of its own — and
+ * pops an in-app toast when a reminder-contest is starting within
+ * REMINDER_WINDOW_MS. Coordinates with other open tabs via BroadcastChannel
+ * so simultaneous tabs don't both show the same toast. Each reminder only
  * ever toasts once — the backend persists `notifiedAt` so this survives
- * page reloads/navigation.
+ * page reloads/navigation, and BroadcastChannel handles the same-instant
+ * multi-tab case that a reload wouldn't catch.
  */
 export default function ContestReminderNotifier() {
   const { isAuthenticated } = useAuth();
+  const { reminders } = useReminders();
   const [toast, setToast] = useState(null);
   const shownThisSession = useRef(new Set());
+  const channelRef = useRef(null);
 
   useEffect(() => {
-    if (!isAuthenticated) return;
+    channelRef.current = createReminderChannel();
+    const unsubscribe = channelRef.current.onClaim((contestId) => {
+      // Another tab already claimed this reminder — suppress it here too.
+      shownThisSession.current.add(contestId);
+      setToast((current) => (current?.contestId === contestId ? null : current));
+    });
+    return unsubscribe;
+  }, []);
 
-    let cancelled = false;
+  useEffect(() => {
+    if (!isAuthenticated || !reminders.length) return;
 
-    const poll = async () => {
-      try {
-        const { data } = await getMyActiveReminders();
-        if (cancelled) return;
+    const now = Date.now();
+    const due = reminders.find((c) => {
+      if (c.notifiedAt) return false;
+      if (shownThisSession.current.has(c.contestId)) return false;
+      const msUntilStart = c.startTimeSeconds * 1000 - now;
+      return msUntilStart > 0 && msUntilStart <= REMINDER_WINDOW_MS;
+    });
 
-        const now = Date.now();
-        const due = (data.data || []).find((c) => {
-          if (c.notifiedAt) return false;
-          if (shownThisSession.current.has(c.contestId)) return false;
-          const msUntilStart = c.startTimeSeconds * 1000 - now;
-          return msUntilStart > 0 && msUntilStart <= REMINDER_WINDOW_MS;
-        });
-
-        if (due) {
-          shownThisSession.current.add(due.contestId);
-          const minutesLeft = Math.max(
-            1,
-            Math.round((due.startTimeSeconds * 1000 - now) / 60000)
-          );
-          setToast({ ...due, minutesLeft });
-          markReminderNotified(due.contestId).catch(() => {});
-        }
-      } catch {
-        // Silent — non-critical background polling.
-      }
-    };
-
-    poll();
-    const id = setInterval(poll, POLL_INTERVAL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(id);
-    };
-  }, [isAuthenticated]);
+    if (due) {
+      shownThisSession.current.add(due.contestId);
+      channelRef.current?.postClaim(due.contestId);
+      const minutesLeft = Math.max(1, Math.round((due.startTimeSeconds * 1000 - now) / 60000));
+      setToast({ ...due, minutesLeft });
+      markReminderNotified(due.contestId).catch(() => {});
+    }
+  }, [isAuthenticated, reminders]);
 
   if (!toast) return null;
 

--- a/frontend/src/context/ReminderContext.jsx
+++ b/frontend/src/context/ReminderContext.jsx
@@ -1,0 +1,58 @@
+import { createContext, useContext, useState, useEffect, useRef, useCallback } from "react";
+import { useAuth } from "./AuthContext";
+import { getMyActiveReminders } from "../services/contestService";
+
+const ReminderContext = createContext(null);
+
+const POLL_INTERVAL_MS = 30_000; // fast enough for the notifier's reminder window
+
+/**
+ * Single owner of "my active reminders" polling per browser tab. The bell
+ * badge and the toast notifier both consume this instead of each running
+ * their own interval — halves the redundant network/DB work per tab.
+ */
+export function ReminderProvider({ children }) {
+  const { isAuthenticated } = useAuth();
+  const [reminders, setReminders] = useState([]);
+  const cancelledRef = useRef(false);
+
+  const poll = useCallback(async () => {
+    try {
+      const { data } = await getMyActiveReminders();
+      if (cancelledRef.current) return;
+      setReminders(data.data || []);
+    } catch {
+      // Silent — consumers just don't get an update this cycle.
+    }
+  }, []);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+
+    if (!isAuthenticated) {
+      setReminders([]);
+      return;
+    }
+
+    poll();
+    const id = setInterval(poll, POLL_INTERVAL_MS);
+    return () => {
+      cancelledRef.current = true;
+      clearInterval(id);
+    };
+  }, [isAuthenticated, poll]);
+
+  return (
+    <ReminderContext.Provider value={{ reminders, refetch: poll }}>
+      {children}
+    </ReminderContext.Provider>
+  );
+}
+
+export function useReminders() {
+  const ctx = useContext(ReminderContext);
+  if (!ctx) {
+    throw new Error("useReminders must be used within a ReminderProvider");
+  }
+  return ctx;
+}

--- a/frontend/src/context/ReminderContext.jsx
+++ b/frontend/src/context/ReminderContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useRef, useCallback } from "react";
+import { createContext, useContext, useState, useEffect, useCallback } from "react";
 import { useAuth } from "./AuthContext";
 import { getMyActiveReminders } from "../services/contestService";
 
@@ -14,12 +14,12 @@ const POLL_INTERVAL_MS = 30_000; // fast enough for the notifier's reminder wind
 export function ReminderProvider({ children }) {
   const { isAuthenticated } = useAuth();
   const [reminders, setReminders] = useState([]);
-  const cancelledRef = useRef(false);
 
+  // Manual refetch (exposed via context) is independent of any single
+  // effect's cancellation scope, so it's safe for it to always write.
   const poll = useCallback(async () => {
     try {
       const { data } = await getMyActiveReminders();
-      if (cancelledRef.current) return;
       setReminders(data.data || []);
     } catch {
       // Silent — consumers just don't get an update this cycle.
@@ -27,20 +27,33 @@ export function ReminderProvider({ children }) {
   }, []);
 
   useEffect(() => {
-    cancelledRef.current = false;
+    // Scoped to THIS effect invocation only. Unlike a shared ref, this
+    // cannot be reset by a later effect run — once cleanup sets it, any
+    // still-in-flight response from THIS session is permanently ignored,
+    // even if a new (e.g. unauthenticated) effect run has already started.
+    let cancelled = false;
 
     if (!isAuthenticated) {
       setReminders([]);
       return;
     }
 
-    poll();
-    const id = setInterval(poll, POLL_INTERVAL_MS);
+    const safePoll = async () => {
+      try {
+        const { data } = await getMyActiveReminders();
+        if (!cancelled) setReminders(data.data || []);
+      } catch {
+        // Silent — consumers just don't get an update this cycle.
+      }
+    };
+
+    safePoll();
+    const id = setInterval(safePoll, POLL_INTERVAL_MS);
     return () => {
-      cancelledRef.current = true;
+      cancelled = true;
       clearInterval(id);
     };
-  }, [isAuthenticated, poll]);
+  }, [isAuthenticated]);
 
   return (
     <ReminderContext.Provider value={{ reminders, refetch: poll }}>

--- a/frontend/src/context/ReminderContext.test.jsx
+++ b/frontend/src/context/ReminderContext.test.jsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { ReminderProvider, useReminders } from "./ReminderContext";
+
+// waitFor from Testing Library polls using real timers internally, which
+// deadlocks against vi.useFakeTimers(). Flush pending microtasks (the
+// resolved mock promises) manually instead.
+const flush = () => act(async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+});
+
+const mockUseAuth = vi.fn();
+vi.mock("./AuthContext", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const mockGetMyActiveReminders = vi.fn();
+vi.mock("../services/contestService", () => ({
+  getMyActiveReminders: (...args) => mockGetMyActiveReminders(...args),
+}));
+
+/**
+ * Renders raw values from useReminders(), plus a counter of how many times
+ * the underlying API was actually called — the counter is read directly
+ * from the mock rather than duplicated in component state, so it reflects
+ * ground truth regardless of render timing.
+ */
+function ReminderConsumer() {
+  const { reminders } = useReminders();
+  return (
+    <div>
+      <span data-testid="count">{reminders.length}</span>
+      <ul>
+        {reminders.map((r) => (
+          <li key={r.contestId}>{r.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+describe("ReminderContext", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetMyActiveReminders.mockReset();
+    mockUseAuth.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("throws a clear error when useReminders is used outside a ReminderProvider", () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    // Suppress the expected React error-boundary console noise for this case.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<ReminderConsumer />)).toThrow(
+      "useReminders must be used within a ReminderProvider"
+    );
+    spy.mockRestore();
+  });
+
+  it("does not poll at all when the user is not authenticated", async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false });
+    render(
+      <ReminderProvider>
+        <ReminderConsumer />
+      </ReminderProvider>
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(mockGetMyActiveReminders).not.toHaveBeenCalled();
+    expect(screen.getByTestId("count").textContent).toBe("0");
+  });
+
+  it("polls immediately on mount, then exactly once per 30s interval — a single shared loop, not two", async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    mockGetMyActiveReminders.mockResolvedValue({ data: { data: [{ contestId: 1, name: "Round 1" }] } });
+
+    render(
+      <ReminderProvider>
+        <ReminderConsumer />
+      </ReminderProvider>
+    );
+
+    await flush();
+    expect(mockGetMyActiveReminders).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("count").textContent).toBe("1");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(mockGetMyActiveReminders).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(mockGetMyActiveReminders).toHaveBeenCalledTimes(3);
+  });
+
+  it("multiple consumers reading useReminders() at the same time do not each trigger their own poll", async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    mockGetMyActiveReminders.mockResolvedValue({ data: { data: [] } });
+
+    render(
+      <ReminderProvider>
+        <ReminderConsumer />
+        <ReminderConsumer />
+      </ReminderProvider>
+    );
+
+    await flush();
+    expect(mockGetMyActiveReminders).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    // Still just ONE call per interval tick, even with two consumers mounted
+    // — this is the actual assertion behind "bell and notifier share one
+    // poll instead of each running their own."
+    expect(mockGetMyActiveReminders).toHaveBeenCalledTimes(2);
+  });
+
+  it("silently keeps the previous reminder list on a failed poll, rather than throwing or clearing state", async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    mockGetMyActiveReminders
+      .mockResolvedValueOnce({ data: { data: [{ contestId: 1, name: "Round 1" }] } })
+      .mockRejectedValueOnce(new Error("network error"));
+
+    render(
+      <ReminderProvider>
+        <ReminderConsumer />
+      </ReminderProvider>
+    );
+
+    await flush();
+    expect(screen.getByTestId("count").textContent).toBe("1");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    // The failed poll should not wipe out the previously loaded reminders.
+    expect(screen.getByTestId("count").textContent).toBe("1");
+  });
+
+  it("resets reminders to empty when auth flips from true to false", async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    mockGetMyActiveReminders.mockResolvedValue({ data: { data: [{ contestId: 1, name: "Round 1" }] } });
+
+    const { rerender } = render(
+      <ReminderProvider>
+        <ReminderConsumer />
+      </ReminderProvider>
+    );
+
+    await flush();
+    expect(screen.getByTestId("count").textContent).toBe("1");
+
+    mockUseAuth.mockReturnValue({ isAuthenticated: false });
+    rerender(
+      <ReminderProvider>
+        <ReminderConsumer />
+      </ReminderProvider>
+    );
+
+    await flush();
+    expect(screen.getByTestId("count").textContent).toBe("0");
+  });
+});

--- a/frontend/src/hooks/useContests.js
+++ b/frontend/src/hooks/useContests.js
@@ -77,11 +77,12 @@ export const useContests = () => {
   const contestsWithMeta = useMemo(() => {
     return contests.map((contest) => {
       const startMs = contest.startTimeSeconds * 1000;
-      const endMs = startMs + contest.durationSeconds * 1000;
+      const isTesting = ["PENDING_SYSTEM_TEST", "SYSTEM_TEST"].includes(contest.phase);
       return {
         ...contest,
         hasReminder: reminderIds.includes(contest.contestId),
-        isRunning: now >= startMs && now < endMs,
+        isRunning: contest.phase === "CODING" && now >= startMs,
+        isTesting,
         msUntilStart: startMs - now,
       };
     });

--- a/frontend/src/layouts/MainLayout.jsx
+++ b/frontend/src/layouts/MainLayout.jsx
@@ -1,16 +1,19 @@
 import Navbar from "../components/shared/Navbar";
 import Footer from "../components/shared/Footer";
 import ContestReminderNotifier from "../components/shared/ContestReminderNotifier";
+import { ReminderProvider } from "../context/ReminderContext";
 
 export default function MainLayout({ children }) {
   return (
-    <div className="min-h-screen bg-white text-black flex flex-col font-sans">
-      <Navbar />
-      <main className="flex-1 w-full flex flex-col">
-        {children}
-      </main>
-      <Footer />
-      <ContestReminderNotifier />
-    </div>
+    <ReminderProvider>
+      <div className="min-h-screen bg-white text-black flex flex-col font-sans">
+        <Navbar />
+        <main className="flex-1 w-full flex flex-col">
+          {children}
+        </main>
+        <Footer />
+        <ContestReminderNotifier />
+      </div>
+    </ReminderProvider>
   );
 }

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,1 +1,9 @@
 import '@testing-library/jest-dom'
+
+// jsdom does not implement BroadcastChannel. Explicitly install Node's
+// built-in implementation onto globalThis so tests get consistent behavior
+// regardless of which jsdom version is resolved in a given environment.
+if (typeof globalThis.BroadcastChannel === 'undefined') {
+  const { BroadcastChannel } = await import('node:worker_threads')
+  globalThis.BroadcastChannel = BroadcastChannel
+}

--- a/frontend/src/utils/reminderBroadcast.js
+++ b/frontend/src/utils/reminderBroadcast.js
@@ -1,0 +1,30 @@
+const CHANNEL_NAME = "codelens-contest-reminders";
+
+/**
+ * Thin wrapper around BroadcastChannel for cross-tab reminder coordination.
+ * Falls back to a no-op if the browser doesn't support it (Safari < 15.4,
+ * some older browsers) — cross-tab dedupe is a nice-to-have, not required
+ * for correctness, since the server's `notifiedAt` remains the durable
+ * source of truth either way.
+ */
+export function createReminderChannel() {
+  if (typeof BroadcastChannel === "undefined") {
+    return {
+      postClaim: () => {},
+      onClaim: () => () => {},
+    };
+  }
+
+  const channel = new BroadcastChannel(CHANNEL_NAME);
+
+  return {
+    postClaim: (contestId) => channel.postMessage({ type: "claimed", contestId }),
+    onClaim: (handler) => {
+      const listener = (event) => {
+        if (event.data?.type === "claimed") handler(event.data.contestId);
+      };
+      channel.addEventListener("message", listener);
+      return () => channel.removeEventListener("message", listener);
+    },
+  };
+}

--- a/frontend/src/utils/reminderBroadcast.test.js
+++ b/frontend/src/utils/reminderBroadcast.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { createReminderChannel } from "./reminderBroadcast";
+
+describe("createReminderChannel", () => {
+  it("delivers a claimed contestId from one channel instance to another (cross-tab simulation)", async () => {
+    const tabA = createReminderChannel();
+    const tabB = createReminderChannel();
+
+    const received = await new Promise((resolve) => {
+      tabB.onClaim((contestId) => resolve(contestId));
+      tabA.postClaim(42);
+    });
+
+    expect(received).toBe(42);
+  });
+
+  it("does not invoke the handler for unrelated message shapes", async () => {
+    const tabA = createReminderChannel();
+    const tabB = createReminderChannel();
+    const handler = vi.fn();
+
+    tabB.onClaim(handler);
+
+    // A message on the same channel name but not our { type: "claimed" }
+    // shape should be ignored, not crash or trigger the handler.
+    const raw = new BroadcastChannel("codelens-contest-reminders");
+    raw.postMessage({ type: "something-else", contestId: 7 });
+    raw.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(handler).not.toHaveBeenCalled();
+
+    // Sanity check the same tabB instance still works for a real claim.
+    const received = await new Promise((resolve) => {
+      tabB.onClaim((contestId) => resolve(contestId));
+      tabA.postClaim(99);
+    });
+    expect(received).toBe(99);
+  });
+
+  it("onClaim's returned unsubscribe function stops further delivery", async () => {
+    const tabA = createReminderChannel();
+    const tabB = createReminderChannel();
+    const handler = vi.fn();
+
+    const unsubscribe = tabB.onClaim(handler);
+    unsubscribe();
+
+    tabA.postClaim(5);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("falls back to safe no-ops when BroadcastChannel is unavailable", () => {
+    const original = globalThis.BroadcastChannel;
+    // eslint-disable-next-line no-undefined
+    globalThis.BroadcastChannel = undefined;
+
+    try {
+      const channel = createReminderChannel();
+      // Should not throw when called, and postClaim/onClaim should behave
+      // as inert no-ops.
+      expect(() => channel.postClaim(1)).not.toThrow();
+      const unsubscribe = channel.onClaim(() => {});
+      expect(() => unsubscribe()).not.toThrow();
+    } finally {
+      globalThis.BroadcastChannel = original;
+    }
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -7,5 +7,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./src/test/setup.js'],
   },
 })

--- a/server/modules/contests/repository.js
+++ b/server/modules/contests/repository.js
@@ -19,7 +19,7 @@ class ContestRepository {
   static async getUpcomingContests(platform = "codeforces") {
     return Contest.find({
       platform,
-      phase: { $in: ["BEFORE", "CODING"] },
+      phase: { $in: ["BEFORE", "CODING", "PENDING_SYSTEM_TEST", "SYSTEM_TEST"] },
     })
       .sort({ startTimeSeconds: 1 })
       .lean();
@@ -27,6 +27,16 @@ class ContestRepository {
 
   static async findByContestId(platform, contestId) {
     return Contest.findOne({ platform, contestId }).lean();
+  }
+
+  static async getNonFinishedContestIds(platform = "codeforces") {
+    const docs = await Contest.find({
+      platform,
+      phase: { $ne: "FINISHED" },
+    })
+      .select("contestId -_id")
+      .lean();
+    return new Set(docs.map((d) => d.contestId));
   }
 
   static async addReminder(userId, platform, contestId) {
@@ -77,18 +87,18 @@ class ContestRepository {
   }
 
   static async pruneStaleReminders(platform = "codeforces") {
-    const finishedContestIds = await Contest.find({
+    const staleContestIds = await Contest.find({
       platform,
-      phase: "FINISHED",
+      phase: { $nin: ["BEFORE", "CODING"] },
     })
       .select("contestId -_id")
       .lean();
 
-    if (!finishedContestIds.length) return;
+    if (!staleContestIds.length) return;
 
     await ContestReminder.deleteMany({
       platform,
-      contestId: { $in: finishedContestIds.map((c) => c.contestId) },
+      contestId: { $in: staleContestIds.map((c) => c.contestId) },
     });
   }
 }

--- a/server/modules/contests/service.js
+++ b/server/modules/contests/service.js
@@ -2,6 +2,8 @@ import ApiError from "../../utils/ApiError.js";
 import ContestRepository from "./repository.js";
 import { cfGetContestList } from "../../utils/codeforcesApi.js";
 
+// NOTE: any value returned here must have a corresponding entry in
+// frontend/src/components/contests/UpcomingContestsList.jsx's DIVISIONS array.
 const parseDivision = (name = "") => {
   const n = name.toLowerCase();
   if (n.includes("div. 1") && n.includes("div. 2")) return "Div. 1 + 2";
@@ -30,21 +32,43 @@ const normalizeContest = (c) => ({
 });
 
 class ContestService {
-  static async syncCodeforcesContests() {
-    const contests = await cfGetContestList(false);
+  /**
+   * @param {Object} [deps] - injectable dependencies, for testing only.
+   *   Production callers should never need to pass this.
+   * @param {Function} [deps.fetchContests] - defaults to cfGetContestList.
+   */
+  static async syncCodeforcesContests({ fetchContests = cfGetContestList } = {}) {
+    const contests = await fetchContests(false);
 
-    const relevant = contests.filter((c) =>
-      ["BEFORE", "CODING", "FINISHED"].includes(c.phase)
+    // Every phase we care about tracking locally. Testing phases are
+    // included so a cached BEFORE/CODING document is never left stranded —
+    // it must be able to transition all the way to FINISHED.
+    const trackedPhases = ["BEFORE", "CODING", "PENDING_SYSTEM_TEST", "SYSTEM_TEST", "FINISHED"];
+    const relevant = contests.filter((c) => trackedPhases.includes(c.phase));
+
+    const activeOrTesting = relevant.filter((c) => c.phase !== "FINISHED");
+
+    // Reconciliation set: any contest we already have cached as non-finished
+    // MUST be updated to whatever the API now reports, even if it has now
+    // moved to FINISHED and would otherwise fall outside the display window
+    // below. This is what prevents a stranded stale document.
+    const existingNonFinishedIds = await ContestRepository.getNonFinishedContestIds("codeforces");
+    const reconciledFinished = relevant.filter(
+      (c) => c.phase === "FINISHED" && existingNonFinishedIds.has(c.id)
     );
 
-    const finished = relevant
+    // Separate retention concern: how many *newly seen* finished contests to
+    // persist for display purposes, independent of reconciliation above.
+    const recentFinished = relevant
       .filter((c) => c.phase === "FINISHED")
       .sort((a, b) => b.startTimeSeconds - a.startTimeSeconds)
       .slice(0, 20);
 
-    const upcomingOrRunning = relevant.filter((c) => c.phase !== "FINISHED");
+    const finishedById = new Map(
+      [...reconciledFinished, ...recentFinished].map((c) => [c.id, c])
+    );
 
-    const docs = [...upcomingOrRunning, ...finished].map(normalizeContest);
+    const docs = [...activeOrTesting, ...finishedById.values()].map(normalizeContest);
 
     await ContestRepository.bulkUpsertContests(docs);
     await ContestRepository.pruneStaleReminders("codeforces");

--- a/server/modules/contests/service.test.js
+++ b/server/modules/contests/service.test.js
@@ -9,7 +9,13 @@ describe("ContestService.syncCodeforcesContests phase reconciliation", () => {
   test("a locally-tracked non-finished contest is reconciled to FINISHED even outside the 20-item window", async () => {
     const fetchContests = async () => [
       { id: 999, name: "Old Contest", phase: "FINISHED", startTimeSeconds: 1000, durationSeconds: 7200 },
-      // ...20 newer finished contests would normally push #999 out of the window
+      ...Array.from({ length: 20 }, (_, index) => ({
+        id: index + 1,
+        name: `New Contest ${index + 1}`,
+        phase: "FINISHED",
+        startTimeSeconds: 2000 + index,
+        durationSeconds: 7200,
+      })),
     ];
     mock.method(ContestRepository, "getNonFinishedContestIds", async () => new Set([999]));
     let upsertedDocs;
@@ -22,9 +28,10 @@ describe("ContestService.syncCodeforcesContests phase reconciliation", () => {
     assert.equal(reconciled?.phase, "FINISHED");
   });
 
-  test("PENDING_SYSTEM_TEST and SYSTEM_TEST phases are persisted, not dropped", async () => {
+  test("PENDING_SYSTEM_TEST and SYSTEM_TEST phases are both persisted, not dropped", async () => {
     const fetchContests = async () => [
-      { id: 1, name: "Testing Contest", phase: "SYSTEM_TEST", startTimeSeconds: 1000, durationSeconds: 7200 },
+      { id: 1, name: "Pending Test", phase: "PENDING_SYSTEM_TEST", startTimeSeconds: 1000, durationSeconds: 7200 },
+      { id: 2, name: "System Test", phase: "SYSTEM_TEST", startTimeSeconds: 1000, durationSeconds: 7200 },
     ];
     mock.method(ContestRepository, "getNonFinishedContestIds", async () => new Set());
     let upsertedDocs;
@@ -33,8 +40,10 @@ describe("ContestService.syncCodeforcesContests phase reconciliation", () => {
 
     await ContestService.syncCodeforcesContests({ fetchContests });
 
-    assert.equal(upsertedDocs.length, 1);
-    assert.equal(upsertedDocs[0].phase, "SYSTEM_TEST");
+    assert.deepEqual(
+      upsertedDocs.map((doc) => doc.phase).sort(),
+      ["PENDING_SYSTEM_TEST", "SYSTEM_TEST"]
+    );
   });
 
   test("a newly-seen finished contest within the 20-item window is still persisted (retention path unaffected)", async () => {

--- a/server/modules/contests/service.test.js
+++ b/server/modules/contests/service.test.js
@@ -1,0 +1,68 @@
+import { test, describe, mock, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import ContestRepository from "./repository.js";
+import ContestService from "./service.js";
+
+describe("ContestService.syncCodeforcesContests phase reconciliation", () => {
+  beforeEach(() => mock.restoreAll());
+
+  test("a locally-tracked non-finished contest is reconciled to FINISHED even outside the 20-item window", async () => {
+    const fetchContests = async () => [
+      { id: 999, name: "Old Contest", phase: "FINISHED", startTimeSeconds: 1000, durationSeconds: 7200 },
+      // ...20 newer finished contests would normally push #999 out of the window
+    ];
+    mock.method(ContestRepository, "getNonFinishedContestIds", async () => new Set([999]));
+    let upsertedDocs;
+    mock.method(ContestRepository, "bulkUpsertContests", async (docs) => { upsertedDocs = docs; });
+    mock.method(ContestRepository, "pruneStaleReminders", async () => {});
+
+    await ContestService.syncCodeforcesContests({ fetchContests });
+
+    const reconciled = upsertedDocs.find((d) => d.contestId === 999);
+    assert.equal(reconciled?.phase, "FINISHED");
+  });
+
+  test("PENDING_SYSTEM_TEST and SYSTEM_TEST phases are persisted, not dropped", async () => {
+    const fetchContests = async () => [
+      { id: 1, name: "Testing Contest", phase: "SYSTEM_TEST", startTimeSeconds: 1000, durationSeconds: 7200 },
+    ];
+    mock.method(ContestRepository, "getNonFinishedContestIds", async () => new Set());
+    let upsertedDocs;
+    mock.method(ContestRepository, "bulkUpsertContests", async (docs) => { upsertedDocs = docs; });
+    mock.method(ContestRepository, "pruneStaleReminders", async () => {});
+
+    await ContestService.syncCodeforcesContests({ fetchContests });
+
+    assert.equal(upsertedDocs.length, 1);
+    assert.equal(upsertedDocs[0].phase, "SYSTEM_TEST");
+  });
+
+  test("a newly-seen finished contest within the 20-item window is still persisted (retention path unaffected)", async () => {
+    const fetchContests = async () => [
+      { id: 2, name: "Recent Finished", phase: "FINISHED", startTimeSeconds: 5000, durationSeconds: 7200 },
+    ];
+    mock.method(ContestRepository, "getNonFinishedContestIds", async () => new Set());
+    let upsertedDocs;
+    mock.method(ContestRepository, "bulkUpsertContests", async (docs) => { upsertedDocs = docs; });
+    mock.method(ContestRepository, "pruneStaleReminders", async () => {});
+
+    await ContestService.syncCodeforcesContests({ fetchContests });
+
+    assert.equal(upsertedDocs.length, 1);
+    assert.equal(upsertedDocs[0].contestId, 2);
+  });
+
+  test("BEFORE and CODING phases pass through untouched, unaffected by reconciliation logic", async () => {
+    const fetchContests = async () => [
+      { id: 3, name: "Upcoming Contest", phase: "BEFORE", startTimeSeconds: 9999, durationSeconds: 7200 },
+    ];
+    mock.method(ContestRepository, "getNonFinishedContestIds", async () => new Set());
+    let upsertedDocs;
+    mock.method(ContestRepository, "bulkUpsertContests", async (docs) => { upsertedDocs = docs; });
+    mock.method(ContestRepository, "pruneStaleReminders", async () => {});
+
+    await ContestService.syncCodeforcesContests({ fetchContests });
+
+    assert.equal(upsertedDocs[0].phase, "BEFORE");
+  });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
# 📌 Pull Request Summary

## 🔗 Related Issue
Closes #278

---

## 📝 Description

Provide a clear and concise summary of the changes made in this pull request.

### Changes Made
* Added phase reconciliation to `syncCodeforcesContests()`: any contest already cached locally as non-finished is now force-updated to its true current phase on every sync, even if it would otherwise fall outside the 20-most-recent-finished retention window, preventing a contest from being stranded showing as upcoming/live long after it has actually ended.
* Extended tracked phases to include `PENDING_SYSTEM_TEST` and `SYSTEM_TEST`, so these intermediate states are persisted instead of silently dropped between `CODING` and `FINISHED`.
* `pruneStaleReminders` now removes reminders for any contest outside `BEFORE`/`CODING` (not just `FINISHED`), so a reminder can't linger for a contest that's mid-system-test.
* `syncCodeforcesContests()` now accepts an injectable `fetchContests` dependency (defaulting to the real API call), enabling deterministic unit tests without hitting ESM's frozen named-export limitation.
* Frontend now derives contest run/testing state from the backend's authoritative `phase` field instead of pure client-side time math; `ContestCountdown` gets a new "System Testing" display state.
* Added `ReminderProvider` (`ReminderContext.jsx`): the navbar reminder bell and the toast notifier now share a single polling loop per browser tab instead of each running its own independent interval, halving redundant network/DB load.
* Added `BroadcastChannel`-based cross-tab coordination (`reminderBroadcast.js`) so two simultaneously open tabs don't both show the same reminder toast, with a safe no-op fallback for browsers without `BroadcastChannel` support.
* Completed the division filter list in `UpcomingContestsList` to include every category `parseDivision` can actually produce (`Div. 1 + 2`, `Kotlin Heroes`, `ICPC`, `Other`), plus a comment linking the two so they don't drift apart again.
* Added backend tests (`node:test`) covering the reconciliation logic, and set up `vitest` for the frontend (previously no test tooling existed) with tests covering the shared-polling behavior and cross-tab broadcast logic.

### Motivation
This resolves the 5 Medium-severity findings from the production review of #269: contest documents could get permanently stuck showing a stale phase once pushed outside the sync's retention window; the reminder bell and toast notifier each independently polled the same endpoint, doubling load for no benefit; two open tabs could both show a duplicate reminder toast for the same contest; and the division filter list was missing several categories the backend already classifies contests into. Together these directly affect data correctness (a contest shown as "live" hours after it ended) and UX polish (duplicate toasts, incomplete filtering) for every user of the contest tracker.

---

## 🚀 Type of Change

Select all that apply:
* [x] Bug Fix
* [ ] New Feature
* [x] Enhancement
* [ ] Documentation Update
* [ ] Refactoring
* [ ] Performance Improvement
* [ ] DevOps / Tooling
* [ ] Other

---

## 🧪 Testing

### Verification
* [x] Tested Locally
* [ ] Existing Tests Passed
* [x] New Tests Added
* [ ] No Testing Required

### Test Details
- **Backend:** Added `node:test` coverage in `server/modules/contests/service.test.js` for the reconciliation logic, verifying a locally-tracked non-finished contest is correctly reconciled to `FINISHED` even outside the 20-item retention window, that `PENDING_SYSTEM_TEST`/`SYSTEM_TEST` phases are persisted rather than dropped, and that normal `BEFORE`/`CODING`/newly-finished contests pass through unaffected. All pass alongside the existing `contestSync` suite (`npm test`).
- **Frontend:** Set up `vitest` + Testing Library (no prior test tooling in the repo) and added 10 tests across two files: `ReminderContext.test.jsx` verifies exactly one API call fires per 30s polling interval regardless of how many consumers (bell + notifier) are mounted, that polling stops entirely when logged out, that a failed poll doesn't wipe existing data, and that auth-state changes correctly reset reminders; `reminderBroadcast.test.js` verifies cross-tab claim delivery, that unrelated message shapes are ignored, that unsubscribing stops delivery, and the safe no-op fallback when `BroadcastChannel` is unavailable. All 10 pass (`npm test`).
- **Manual:** Ran a full production build (`npm run build`) to confirm no build-time errors across all touched files, and did a visual pass through the app in dev mode confirming no console errors and normal rendering.

---

## 📸 Screenshots / Demo (If Applicable)

N/A - this PR is primarily backend reconciliation logic and shared frontend polling/broadcast infrastructure, not new UI. The one visible change (expanded division filter buttons, "System Testing" countdown label) uses existing styling patterns already present elsewhere in the app.

---

## ✅ Checklist
* [x] I have read and followed the contribution guidelines.
* [x] I have self-reviewed my changes.
* [x] My changes are limited to the scope of this issue.
* [ ] Documentation has been updated where necessary.
* [x] No unnecessary files or unrelated changes have been included.
* [x] The related issue has been linked correctly.
* [x] All applicable testing and validation steps have been completed.

---

## 📚 Additional Notes
This is the 3rd of the 4 issues that came out of the #269 production review, #276/#280 and #277/#284 already address the High-severity cron duplication findings; #279 (Low severity) is still outstanding. The frontend previously had zero test infrastructure - `vitest.config.js` and the testing-library setup added here can be reused for any future frontend test coverage in the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “System Testing” status for contests in progress between coding and final results.
  * Improved contest phase tracking and visibility, including recently completed contests.
  * Centralized reminder updates across the app and coordinated notifications across browser tabs.

* **Bug Fixes**
  * Prevented duplicate reminder notifications and improved stale reminder cleanup.

* **Tests**
  * Added automated frontend and backend test suites covering reminders, contest phases, and cross-tab notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->