### PR TITLE
fix: verifyConnection binds client handle instead of stored pending handle

### DIFF
--- a/server/modules/codeforces/service.js
+++ b/server/modules/codeforces/service.js
@@ -205,6 +205,12 @@ class CodeforcesService {
       throw new ApiError(400, "No pending verification. Please re-initiate connection.");
     }
 
+    // Bind to the handle vetted during initiateConnection (the one the
+    // duplicate-handle uniqueness guard ran against), not whatever the client
+    // re-sends now. Otherwise the finally-bound handle can diverge from the one
+    // that passed the uniqueness check, producing inconsistent state.
+    handle = profile.handle;
+
     if (new Date() > profile.verificationExpiry) {
       throw new ApiError(400, "Verification code expired. Please re-initiate connection.");
     }


### PR DESCRIPTION
## Problem
`codeforces/service.js` `verifyConnection` loads the pending profile by `userId`, but the CF re-fetch, `setUserCodeforcesHandle` and the background `syncUserData` all use `handle` from `req.body` — not `profile.handle`.

The duplicate-handle uniqueness guard ("already connected to another account") exists **only** in `initiateConnection`, against the initiate handle. The verify path binds whatever handle the client sends and never re-checks uniqueness, so the finally-bound handle can diverge from the one that passed the uniqueness check → inconsistent state / uniqueness bypass.

## Fix
Rebind `handle = profile.handle` immediately after loading the pending profile, so the entire verify flow uses the vetted, uniqueness-checked handle. `node --check` passes.

Closes #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connection verification now consistently uses the handle validated during initiation, preventing mismatches from client-supplied values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->