### PR TITLE
fix: GitHub dashboard cache never expires — stats frozen forever

### DIFF
--- a/server/modules/github/service.js
+++ b/server/modules/github/service.js
@@ -235,12 +235,19 @@ class GitHubService {
     };
   }
 
-  /** ── Full dashboard (cached) ────────────────────────────────────────── */
+  /** Cached GitHub dashboard data older than this is re-fetched on read. */
+  static #DASHBOARD_CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+  /** ── Full dashboard (cached with TTL) ───────────────────────────────── */
   static async getDashboard(userId) {
     // Check if we have cached data for this user
     let githubData = await GithubData.findOne({ userId });
-    
-    if (githubData && githubData.data) {
+
+    const cacheAge = githubData?.lastSyncedAt
+      ? Date.now() - new Date(githubData.lastSyncedAt).getTime()
+      : Infinity;
+
+    if (githubData && githubData.data && cacheAge < this.#DASHBOARD_CACHE_MAX_AGE_MS) {
       console.log(`[GitHub] ✓ Dashboard returned from cache for user ${userId}`);
       return {
         ...githubData.data,
@@ -248,20 +255,33 @@ class GitHubService {
       };
     }
 
-    // If no cache, fetch fresh data and store it
-    const { token, username } = await this.#getToken(userId);
-    const data = await this.#fetchDashboardData(userId, token, username);
-    
-    await GithubData.findOneAndUpdate(
-      { userId },
-      { userId, data, lastSyncedAt: new Date() },
-      { upsert: true, new: true }
-    );
+    // No cache or stale — fetch fresh data and store it. If the refresh fails
+    // but we still have a (stale) cache, serve that rather than erroring out.
+    try {
+      const { token, username } = await this.#getToken(userId);
+      const data = await this.#fetchDashboardData(userId, token, username);
+      const now = new Date();
 
-    return {
-      ...data,
-      lastSyncedAt: new Date()
-    };
+      await GithubData.findOneAndUpdate(
+        { userId },
+        { userId, data, lastSyncedAt: now },
+        { upsert: true, new: true }
+      );
+
+      return {
+        ...data,
+        lastSyncedAt: now
+      };
+    } catch (err) {
+      if (githubData && githubData.data) {
+        console.warn(`[GitHub] refresh failed for user ${userId}, serving stale cache: ${err.message}`);
+        return {
+          ...githubData.data,
+          lastSyncedAt: githubData.lastSyncedAt
+        };
+      }
+      throw err;
+    }
   }
 
   /** ── Manual Sync Dashboard ─────────────────────────────────────────── */


### PR DESCRIPTION
## Problem
`github/service.js` `getDashboard` returns a cached `GithubData` doc **unconditionally** whenever one exists — no TTL/staleness check. The only refresh path is a manual `POST /sync` (rate-limited 1/15min), so a user who never manually syncs sees GitHub stats frozen at first-fetch forever. `apexContextCompiler.js` feeds this same stale data into the AI system prompt, so APEX also reasons on outdated data.

## Fix
Compare `lastSyncedAt` against a 6-hour TTL in `getDashboard`; re-fetch when stale or missing. If the refresh fails but a (stale) cache exists, serve that rather than erroring — the endpoint stays available offline / on token or rate-limit failures.

`node --check` passes.

Closes #302