### PR TITLE
fix: AI dashboard summary cached permanently, never invalidated

### DIFF
--- a/server/modules/ai/service.js
+++ b/server/modules/ai/service.js
@@ -227,12 +227,20 @@ class AiService {
     const user = await User.findById(userId).select("name email dashboardSummary").lean();
     if (!user) throw new ApiError(401, "User not found.");
 
-    // 2. Return cached summary if it exists
-    if (user.dashboardSummary && user.dashboardSummary.content) {
-      return user.dashboardSummary.content;
+    // 2. Return cached summary if it's still fresh. Without a TTL the summary
+    //    was returned forever — nothing (not a CF sync, not new contests)
+    //    regenerated it, so the "growth insight" could permanently contradict
+    //    the user's current stats.
+    const SUMMARY_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+    const cached = user.dashboardSummary;
+    const summaryAge = cached?.lastGeneratedAt
+      ? Date.now() - new Date(cached.lastGeneratedAt).getTime()
+      : Infinity;
+    if (cached && cached.content && summaryAge < SUMMARY_MAX_AGE_MS) {
+      return cached.content;
     }
 
-    console.log(`[AI] ▶ No cached summary found for ${user.name}. Generating new summary...`);
+    console.log(`[AI] ▶ No fresh cached summary for ${user.name}. Generating new summary...`);
 
     // 3. Fetch data for generation
     const [cfProfile, recentContests] = await Promise.all([


### PR DESCRIPTION
## Problem
`ai/service.js` `getDashboardSummary` stores the generated summary in `user.dashboardSummary.content` and returns it forever — nothing regenerates or invalidates it (not a Codeforces sync, not new contest results), and there's no force-refresh endpoint. The AI "growth insight" a user sees becomes permanently stale and can contradict their current stats.

## Fix
Compare the existing `lastGeneratedAt` field (`User.js:80`) against a 24-hour TTL and regenerate when stale.

`node --check` passes.

Closes #303